### PR TITLE
[SEC-002] Add API key authentication for REST endpoints

### DIFF
--- a/include/firewallo/auth.h
+++ b/include/firewallo/auth.h
@@ -1,0 +1,30 @@
+#ifndef FIREWALLO_AUTH_H
+#define FIREWALLO_AUTH_H
+
+#include <stddef.h>
+
+#define AUTH_TOKEN_MAX 256
+
+/**
+ * Load API token from file. The file should contain a single line with
+ * the token (leading/trailing whitespace is stripped).
+ * Returns 0 on success, -1 on error.
+ * If token_path is NULL, authentication is disabled (all requests pass).
+ */
+int auth_load_token(const char *token_path, char *token_buf, size_t buf_size);
+
+/**
+ * Check whether the given Authorization header value matches the loaded token.
+ * Expected format: "Bearer <token>"
+ * Returns 1 if authorized, 0 if not.
+ * If stored_token is NULL or empty, all requests are authorized (auth disabled).
+ */
+int auth_check_bearer(const char *auth_header, const char *stored_token);
+
+/**
+ * Generate a random API token and write it to the given file path
+ * with mode 0600. Returns 0 on success, -1 on error.
+ */
+int auth_generate_token(const char *token_path);
+
+#endif /* FIREWALLO_AUTH_H */

--- a/include/firewallo/httpd.h
+++ b/include/firewallo/httpd.h
@@ -2,6 +2,7 @@
 #define FIREWALLO_HTTPD_H
 
 #include "firewallo/types.h"
+#include "firewallo/auth.h"
 #include <stddef.h>
 
 #define HTTP_MAX_HEADERS 2048
@@ -15,6 +16,7 @@ typedef struct {
     char path[HTTP_MAX_PATH];
     char query[HTTP_MAX_QUERY];
     char content_type[128];
+    char authorization[AUTH_TOKEN_MAX + 16]; /* "Bearer <token>" */
     size_t content_length;
     char *body;
     size_t body_len;
@@ -38,6 +40,7 @@ typedef struct {
     const char *webroot;
     const char *config_path;
     fw_config_t *config;
+    char api_token[AUTH_TOKEN_MAX]; /* loaded API token (empty = auth disabled) */
     volatile int running;
 } httpd_t;
 

--- a/src/web/auth.c
+++ b/src/web/auth.c
@@ -27,8 +27,14 @@ static void strip_whitespace(char *s)
 
 int auth_load_token(const char *token_path, char *token_buf, size_t buf_size)
 {
-    if (!token_path || !token_buf || buf_size == 0)
+    if (!token_buf || buf_size == 0)
         return -1;
+
+    /* NULL path disables authentication — leave token buffer empty */
+    if (!token_path) {
+        token_buf[0] = '\0';
+        return 0;
+    }
 
     token_buf[0] = '\0';
 
@@ -52,6 +58,15 @@ int auth_load_token(const char *token_path, char *token_buf, size_t buf_size)
     if (!fgets(token_buf, (int)buf_size, fp)) {
         fclose(fp);
         fw_log(LOG_ERROR, "auth: token file is empty: %s", token_path);
+        return -1;
+    }
+
+    /* Detect truncation: if no newline and not at EOF, the token was too long */
+    if (!strchr(token_buf, '\n') && !feof(fp)) {
+        fclose(fp);
+        fw_log(LOG_ERROR, "auth: token too long (exceeds %zu byte buffer): %s",
+               buf_size - 1, token_path);
+        token_buf[0] = '\0';
         return -1;
     }
     fclose(fp);
@@ -132,6 +147,11 @@ int auth_generate_token(const char *token_path)
     if (fd < 0) {
         fw_log(LOG_ERROR, "auth: cannot create token file: %s", token_path);
         return -1;
+    }
+
+    /* Enforce 0600 even if the file already existed with broader permissions */
+    if (fchmod(fd, 0600) != 0) {
+        fw_log(LOG_WARN, "auth: failed to set permissions on token file: %s", token_path);
     }
 
     size_t len = (size_t)token_len;

--- a/src/web/auth.c
+++ b/src/web/auth.c
@@ -1,0 +1,154 @@
+#include "firewallo/auth.h"
+#include "firewallo/log.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <ctype.h>
+#include <time.h>
+
+/* Strip leading and trailing whitespace in-place */
+static void strip_whitespace(char *s)
+{
+    /* leading */
+    char *start = s;
+    while (*start && isspace((unsigned char)*start))
+        start++;
+    if (start != s)
+        memmove(s, start, strlen(start) + 1);
+
+    /* trailing */
+    size_t len = strlen(s);
+    while (len > 0 && isspace((unsigned char)s[len - 1]))
+        s[--len] = '\0';
+}
+
+int auth_load_token(const char *token_path, char *token_buf, size_t buf_size)
+{
+    if (!token_path || !token_buf || buf_size == 0)
+        return -1;
+
+    token_buf[0] = '\0';
+
+    /* Check file permissions — warn if too open */
+    struct stat st;
+    if (stat(token_path, &st) != 0) {
+        fw_log(LOG_ERROR, "auth: cannot stat token file: %s", token_path);
+        return -1;
+    }
+    if ((st.st_mode & 0077) != 0) {
+        fw_log(LOG_WARN, "auth: token file %s has insecure permissions "
+               "(mode %04o, expected 0600)", token_path, st.st_mode & 0777);
+    }
+
+    FILE *fp = fopen(token_path, "r");
+    if (!fp) {
+        fw_log(LOG_ERROR, "auth: cannot open token file: %s", token_path);
+        return -1;
+    }
+
+    if (!fgets(token_buf, (int)buf_size, fp)) {
+        fclose(fp);
+        fw_log(LOG_ERROR, "auth: token file is empty: %s", token_path);
+        return -1;
+    }
+    fclose(fp);
+
+    strip_whitespace(token_buf);
+
+    if (strlen(token_buf) == 0) {
+        fw_log(LOG_ERROR, "auth: token file contains only whitespace: %s", token_path);
+        return -1;
+    }
+
+    fw_log(LOG_INFO, "auth: API token loaded from %s", token_path);
+    return 0;
+}
+
+int auth_check_bearer(const char *auth_header, const char *stored_token)
+{
+    /* If no token is configured, auth is disabled — allow all */
+    if (!stored_token || stored_token[0] == '\0')
+        return 1;
+
+    if (!auth_header || auth_header[0] == '\0')
+        return 0;
+
+    /* Expect "Bearer <token>" */
+    const char *prefix = "Bearer ";
+    size_t prefix_len = 7;
+
+    if (strncmp(auth_header, prefix, prefix_len) != 0)
+        return 0;
+
+    const char *provided = auth_header + prefix_len;
+
+    /* Constant-time comparison to prevent timing attacks */
+    size_t stored_len = strlen(stored_token);
+    size_t provided_len = strlen(provided);
+
+    /* Compare all bytes regardless of mismatch to avoid timing leak */
+    unsigned char result = (stored_len != provided_len) ? 1 : 0;
+    size_t cmp_len = stored_len < provided_len ? stored_len : provided_len;
+    for (size_t i = 0; i < cmp_len; i++)
+        result |= (unsigned char)((unsigned char)stored_token[i] ^ (unsigned char)provided[i]);
+
+    return result == 0 ? 1 : 0;
+}
+
+int auth_generate_token(const char *token_path)
+{
+    static const char charset[] =
+        "abcdefghijklmnopqrstuvwxyz"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "0123456789";
+    const int token_len = 48;
+    char token[49];
+
+    /* Try /dev/urandom first for cryptographic randomness */
+    int fd = open("/dev/urandom", O_RDONLY);
+    if (fd < 0) {
+        fw_log(LOG_ERROR, "auth: cannot open /dev/urandom");
+        return -1;
+    }
+
+    unsigned char randbuf[48];
+    ssize_t n = read(fd, randbuf, sizeof(randbuf));
+    close(fd);
+
+    if (n != (ssize_t)sizeof(randbuf)) {
+        fw_log(LOG_ERROR, "auth: failed to read random bytes");
+        return -1;
+    }
+
+    for (int i = 0; i < token_len; i++)
+        token[i] = charset[randbuf[i] % (sizeof(charset) - 1)];
+    token[token_len] = '\0';
+
+    /* Write token to file with restrictive permissions */
+    fd = open(token_path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+    if (fd < 0) {
+        fw_log(LOG_ERROR, "auth: cannot create token file: %s", token_path);
+        return -1;
+    }
+
+    size_t len = (size_t)token_len;
+    char buf[50];
+    memcpy(buf, token, len);
+    buf[len] = '\n';
+
+    ssize_t written = write(fd, buf, len + 1);
+    close(fd);
+
+    if (written != (ssize_t)(len + 1)) {
+        fw_log(LOG_ERROR, "auth: failed to write token file");
+        return -1;
+    }
+
+    fw_log(LOG_INFO, "auth: generated new API token at %s", token_path);
+    printf("API token generated: %s\n", token);
+    printf("Token file: %s\n", token_path);
+    return 0;
+}

--- a/src/web/httpd.c
+++ b/src/web/httpd.c
@@ -164,9 +164,18 @@ static int parse_request(const char *raw, size_t raw_len, http_request_t *req)
 
 /* ── Send response ─────────────────────────────────────────────────── */
 
-static void send_response(int fd, const http_response_t *resp)
+static void send_response(int fd, const http_response_t *resp, int auth_enabled)
 {
     char header[2048];
+    /* When auth is enabled, do not expose a wildcard CORS origin with
+       Authorization in allowed headers — the API is same-origin and the
+       wildcard would let any website make authenticated cross-origin calls. */
+    const char *cors_headers = auth_enabled
+        ? ""
+        : "Access-Control-Allow-Origin: *\r\n"
+          "Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\r\n"
+          "Access-Control-Allow-Headers: Content-Type, Authorization\r\n";
+
     int hlen = snprintf(header, sizeof(header),
         "HTTP/1.1 %d %s\r\n"
         "Content-Type: %s\r\n"
@@ -177,13 +186,12 @@ static void send_response(int fd, const http_response_t *resp)
         "X-XSS-Protection: 1; mode=block\r\n"
         "Referrer-Policy: no-referrer\r\n"
         "Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'\r\n"
-        "Access-Control-Allow-Origin: *\r\n"
-        "Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\r\n"
-        "Access-Control-Allow-Headers: Content-Type, Authorization\r\n"
+        "%s"
         "\r\n",
         resp->status, resp->status_text,
         resp->content_type,
-        resp->body_len);
+        resp->body_len,
+        cors_headers);
 
     /* Send header */
     ssize_t sent = 0;
@@ -253,7 +261,13 @@ static void handle_connection(httpd_t *srv, int client_fd)
         resp.status = 400;
         fw_strlcpy(resp.status_text, "Bad Request", sizeof(resp.status_text));
         char *err = strdup("{\"error\":true,\"message\":\"Bad request\"}");
-        http_response_set_json(&resp, 400, err);
+        if (!err) {
+            http_response_set_json(&resp, 400,
+                (char *)"{\"error\":true,\"message\":\"Bad request\"}");
+            resp.body_owned = 0;
+        } else {
+            http_response_set_json(&resp, 400, err);
+        }
     } else if (strcmp(req.method, "OPTIONS") == 0) {
         /* CORS preflight */
         resp.status = 204;
@@ -265,7 +279,7 @@ static void handle_connection(httpd_t *srv, int client_fd)
 
     fw_log(LOG_DEBUG, "%s %s -> %d", req.method, req.path, resp.status);
 
-    send_response(client_fd, &resp);
+    send_response(client_fd, &resp, srv->api_token[0] != '\0');
 
     /* Cleanup */
     http_response_free(&resp);

--- a/src/web/httpd.c
+++ b/src/web/httpd.c
@@ -48,6 +48,8 @@ void http_response_set_json(http_response_t *resp, int status, char *json)
     case 201: fw_strlcpy(resp->status_text, "Created", sizeof(resp->status_text)); break;
     case 204: fw_strlcpy(resp->status_text, "No Content", sizeof(resp->status_text)); break;
     case 400: fw_strlcpy(resp->status_text, "Bad Request", sizeof(resp->status_text)); break;
+    case 401: fw_strlcpy(resp->status_text, "Unauthorized", sizeof(resp->status_text)); break;
+    case 403: fw_strlcpy(resp->status_text, "Forbidden", sizeof(resp->status_text)); break;
     case 404: fw_strlcpy(resp->status_text, "Not Found", sizeof(resp->status_text)); break;
     case 405: fw_strlcpy(resp->status_text, "Method Not Allowed", sizeof(resp->status_text)); break;
     case 500: fw_strlcpy(resp->status_text, "Internal Server Error", sizeof(resp->status_text)); break;
@@ -129,6 +131,14 @@ static int parse_request(const char *raw, size_t raw_len, http_request_t *req)
                 vlen = sizeof(req->content_type) - 1;
             memcpy(req->content_type, val, vlen);
             req->content_type[vlen] = '\0';
+        } else if (strncasecmp(h, "Authorization:", 14) == 0) {
+            const char *val = h + 14;
+            while (*val == ' ') val++;
+            size_t vlen = (size_t)(nl - val);
+            if (vlen >= sizeof(req->authorization))
+                vlen = sizeof(req->authorization) - 1;
+            memcpy(req->authorization, val, vlen);
+            req->authorization[vlen] = '\0';
         }
         h = nl + 2;
     }
@@ -169,7 +179,7 @@ static void send_response(int fd, const http_response_t *resp)
         "Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self'\r\n"
         "Access-Control-Allow-Origin: *\r\n"
         "Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS\r\n"
-        "Access-Control-Allow-Headers: Content-Type\r\n"
+        "Access-Control-Allow-Headers: Content-Type, Authorization\r\n"
         "\r\n",
         resp->status, resp->status_text,
         resp->content_type,

--- a/src/web/main.c
+++ b/src/web/main.c
@@ -1,4 +1,5 @@
 #include "firewallo/httpd.h"
+#include "firewallo/auth.h"
 #include "firewallo/config.h"
 #include "firewallo/log.h"
 #include <stdio.h>
@@ -21,11 +22,13 @@ static void print_usage(void)
         "Usage: firewallo-web [options]\n"
         "\n"
         "Options:\n"
-        "  -p, --port <port>      Listen port (default: 8080)\n"
-        "  -b, --bind <addr>      Bind address (default: 0.0.0.0)\n"
-        "  -w, --webroot <path>   Static files directory (default: /usr/local/share/firewallo/web)\n"
-        "  -c, --config <path>    Config file (default: /etc/firewallo/firewallo.json)\n"
-        "  -h, --help             Show this help\n"
+        "  -p, --port <port>         Listen port (default: 8080)\n"
+        "  -b, --bind <addr>         Bind address (default: 0.0.0.0)\n"
+        "  -w, --webroot <path>      Static files directory (default: /usr/local/share/firewallo/web)\n"
+        "  -c, --config <path>       Config file (default: /etc/firewallo/firewallo.json)\n"
+        "  -t, --token-file <path>   API token file for authentication (default: none, auth disabled)\n"
+        "      --generate-token      Generate a new API token and exit\n"
+        "  -h, --help                Show this help\n"
     );
 }
 
@@ -35,26 +38,43 @@ int main(int argc, char *argv[])
     const char *bind_addr = "0.0.0.0";
     const char *webroot = "/usr/local/share/firewallo/web";
     const char *config_path = "/etc/firewallo/firewallo.json";
+    const char *token_path = NULL;
+    int generate_token = 0;
 
     static struct option long_opts[] = {
-        {"port",    required_argument, NULL, 'p'},
-        {"bind",    required_argument, NULL, 'b'},
-        {"webroot", required_argument, NULL, 'w'},
-        {"config",  required_argument, NULL, 'c'},
-        {"help",    no_argument,       NULL, 'h'},
+        {"port",           required_argument, NULL, 'p'},
+        {"bind",           required_argument, NULL, 'b'},
+        {"webroot",        required_argument, NULL, 'w'},
+        {"config",         required_argument, NULL, 'c'},
+        {"token-file",     required_argument, NULL, 't'},
+        {"generate-token", no_argument,       NULL, 'G'},
+        {"help",           no_argument,       NULL, 'h'},
         {NULL, 0, NULL, 0}
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "p:b:w:c:h", long_opts, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "p:b:w:c:t:h", long_opts, NULL)) != -1) {
         switch (opt) {
         case 'p': port = atoi(optarg); break;
         case 'b': bind_addr = optarg; break;
         case 'w': webroot = optarg; break;
         case 'c': config_path = optarg; break;
+        case 't': token_path = optarg; break;
+        case 'G': generate_token = 1; break;
         case 'h': print_usage(); return 0;
         default:  print_usage(); return 1;
         }
+    }
+
+    /* Generate token mode — write token file and exit */
+    if (generate_token) {
+        const char *path = token_path ? token_path : "/etc/firewallo/api.token";
+        fw_log_init(NULL, LOG_INFO);
+        if (auth_generate_token(path) != 0) {
+            fprintf(stderr, "Failed to generate token\n");
+            return 1;
+        }
+        return 0;
     }
 
     /* Load config */
@@ -77,6 +97,18 @@ int main(int argc, char *argv[])
     if (httpd_init(&server, bind_addr, port, webroot, config_path, &cfg) != 0) {
         fprintf(stderr, "Failed to start server on port %d\n", port);
         return 1;
+    }
+
+    /* Load API token for authentication */
+    if (token_path) {
+        if (auth_load_token(token_path, server.api_token, sizeof(server.api_token)) != 0) {
+            fprintf(stderr, "Failed to load API token from %s\n", token_path);
+            return 1;
+        }
+        fw_log(LOG_INFO, "API authentication enabled");
+    } else {
+        server.api_token[0] = '\0';
+        fw_log(LOG_WARN, "No --token-file specified; API authentication is DISABLED");
     }
 
     httpd_run(&server);

--- a/src/web/router.c
+++ b/src/web/router.c
@@ -14,7 +14,13 @@ int router_dispatch(httpd_t *srv, const http_request_t *req, http_response_t *re
         if (!auth_check_bearer(req->authorization, srv->api_token)) {
             fw_log(LOG_WARN, "auth: rejected unauthenticated request to %s", req->path);
             char *err = strdup("{\"error\":true,\"message\":\"Unauthorized: valid Bearer token required\"}");
-            http_response_set_json(resp, 401, err);
+            if (!err) {
+                http_response_set_json(resp, 401,
+                    (char *)"{\"error\":true,\"message\":\"Unauthorized\"}");
+                resp->body_owned = 0;
+            } else {
+                http_response_set_json(resp, 401, err);
+            }
             return 0;
         }
         return api_handle(srv, req, resp);
@@ -23,7 +29,13 @@ int router_dispatch(httpd_t *srv, const http_request_t *req, http_response_t *re
     /* Static files (GET only) */
     if (strcmp(req->method, "GET") != 0) {
         char *err = strdup("{\"error\":true,\"message\":\"Method not allowed\"}");
-        http_response_set_json(resp, 405, err);
+        if (!err) {
+            http_response_set_json(resp, 405,
+                (char *)"{\"error\":true,\"message\":\"Method not allowed\"}");
+            resp->body_owned = 0;
+        } else {
+            http_response_set_json(resp, 405, err);
+        }
         return 0;
     }
 
@@ -33,7 +45,11 @@ int router_dispatch(httpd_t *srv, const http_request_t *req, http_response_t *re
         fw_strlcpy(resp->content_type, "text/html; charset=utf-8", sizeof(resp->content_type));
         const char *body = "<h1>404 Not Found</h1>";
         char *b = strdup(body);
-        http_response_set_body(resp, b, strlen(b), 1);
+        if (!b) {
+            http_response_set_body(resp, (char *)body, strlen(body), 0);
+        } else {
+            http_response_set_body(resp, b, strlen(b), 1);
+        }
     }
 
     return 0;

--- a/src/web/router.c
+++ b/src/web/router.c
@@ -1,14 +1,22 @@
 #include "firewallo/router.h"
 #include "firewallo/api.h"
+#include "firewallo/auth.h"
 #include "firewallo/static_serve.h"
 #include "firewallo/util.h"
+#include "firewallo/log.h"
 #include <stdio.h>
 #include <string.h>
 
 int router_dispatch(httpd_t *srv, const http_request_t *req, http_response_t *resp)
 {
-    /* API routes */
+    /* API routes — require authentication */
     if (strncmp(req->path, "/api/v1/", 8) == 0) {
+        if (!auth_check_bearer(req->authorization, srv->api_token)) {
+            fw_log(LOG_WARN, "auth: rejected unauthenticated request to %s", req->path);
+            char *err = strdup("{\"error\":true,\"message\":\"Unauthorized: valid Bearer token required\"}");
+            http_response_set_json(resp, 401, err);
+            return 0;
+        }
         return api_handle(srv, req, resp);
     }
 


### PR DESCRIPTION
## Task SEC-002 — Add API key authentication for REST endpoints

### Summary
- New `auth.c`/`auth.h` module with constant-time Bearer token comparison and `/dev/urandom` token generation
- Added `--token-file` and `--generate-token` CLI flags to `firewallo-web`
- Auth middleware in router checks `Authorization: Bearer <token>` for all `/api/v1/*` endpoints
- Static file serving remains unauthenticated (web UI access)
- Backward-compatible: no auth enforced when `--token-file` not specified

### Related Issue
Refs #10 (SEC-002)

---
*Generated by Claude Code via `/task-pick`*