### PR TITLE
[SEC-003] Validate interface names and config fields against injection

### DIFF
--- a/include/firewallo/validate.h
+++ b/include/firewallo/validate.h
@@ -27,4 +27,10 @@ int fw_validate_action(const char *action);
 /* Validate comment (alphanumeric, underscore, hyphen, space) */
 int fw_validate_comment(const char *comment);
 
+/* Validate address field: empty, IPv4, or IPv4/CIDR */
+int fw_validate_addr_field(const char *addr);
+
+/* Validate mangle mark (hex string like "0x1" or decimal) */
+int fw_validate_mark(const char *mark);
+
 #endif /* FIREWALLO_VALIDATE_H */

--- a/src/lib/config.c
+++ b/src/lib/config.c
@@ -852,7 +852,7 @@ int fw_config_validate(const fw_config_t *cfg, char *err, size_t errlen)
         }
     }
 
-    /* Validate ports in all chains */
+    /* Validate ports and filter rules in all chains */
     for (int c = 0; c < FW_CHAIN_COUNT; c++) {
         const fw_chain_t *ch = &cfg->chains[c];
         for (int i = 0; i < ch->tcp_port_count; i++) {
@@ -868,6 +868,127 @@ int fw_config_validate(const fw_config_t *cfg, char *err, size_t errlen)
                          ch->udp_ports[i], ch->name);
                 return -1;
             }
+        }
+        /* Validate explicit filter rules (addresses, comments) */
+        for (int i = 0; i < ch->rule_count; i++) {
+            const fw_filter_rule_t *r = &ch->rules[i];
+            if (!fw_validate_addr_field(r->src_addr)) {
+                snprintf(err, errlen, "invalid src_addr in chain %s rule %d: %s",
+                         ch->name, i, r->src_addr);
+                return -1;
+            }
+            if (!fw_validate_addr_field(r->dst_addr)) {
+                snprintf(err, errlen, "invalid dst_addr in chain %s rule %d: %s",
+                         ch->name, i, r->dst_addr);
+                return -1;
+            }
+            if (!fw_validate_comment(r->comment)) {
+                snprintf(err, errlen, "invalid comment in chain %s rule %d",
+                         ch->name, i);
+                return -1;
+            }
+        }
+    }
+
+    /* Validate NAT postrouting comments */
+    for (int i = 0; i < cfg->nat_post_count; i++) {
+        if (!fw_validate_comment(cfg->nat_post[i].comment)) {
+            snprintf(err, errlen, "invalid comment in NAT postrouting rule %d", i);
+            return -1;
+        }
+    }
+
+    /* Validate NAT prerouting comments */
+    for (int i = 0; i < cfg->nat_pre_count; i++) {
+        if (!fw_validate_comment(cfg->nat_pre[i].comment)) {
+            snprintf(err, errlen, "invalid comment in NAT prerouting rule %d", i);
+            return -1;
+        }
+    }
+
+    /* Validate mangle rules */
+    for (int i = 0; i < cfg->mangle_pre_count; i++) {
+        const fw_mangle_rule_t *r = &cfg->mangle_pre[i];
+        if (r->iif[0] && !fw_validate_interface(r->iif)) {
+            snprintf(err, errlen, "invalid iif in mangle prerouting rule %d: %s", i, r->iif);
+            return -1;
+        }
+        if (!fw_validate_addr_field(r->src_addr)) {
+            snprintf(err, errlen, "invalid src_addr in mangle prerouting rule %d: %s", i, r->src_addr);
+            return -1;
+        }
+        if (!fw_validate_addr_field(r->dst_addr)) {
+            snprintf(err, errlen, "invalid dst_addr in mangle prerouting rule %d: %s", i, r->dst_addr);
+            return -1;
+        }
+        if (r->mark[0] && !fw_validate_mark(r->mark)) {
+            snprintf(err, errlen, "invalid mark in mangle prerouting rule %d: %s", i, r->mark);
+            return -1;
+        }
+        if (!fw_validate_comment(r->comment)) {
+            snprintf(err, errlen, "invalid comment in mangle prerouting rule %d", i);
+            return -1;
+        }
+    }
+    for (int i = 0; i < cfg->mangle_post_count; i++) {
+        const fw_mangle_rule_t *r = &cfg->mangle_post[i];
+        if (r->iif[0] && !fw_validate_interface(r->iif)) {
+            snprintf(err, errlen, "invalid iif in mangle postrouting rule %d: %s", i, r->iif);
+            return -1;
+        }
+        if (!fw_validate_addr_field(r->src_addr)) {
+            snprintf(err, errlen, "invalid src_addr in mangle postrouting rule %d: %s", i, r->src_addr);
+            return -1;
+        }
+        if (!fw_validate_addr_field(r->dst_addr)) {
+            snprintf(err, errlen, "invalid dst_addr in mangle postrouting rule %d: %s", i, r->dst_addr);
+            return -1;
+        }
+        if (r->mark[0] && !fw_validate_mark(r->mark)) {
+            snprintf(err, errlen, "invalid mark in mangle postrouting rule %d: %s", i, r->mark);
+            return -1;
+        }
+        if (!fw_validate_comment(r->comment)) {
+            snprintf(err, errlen, "invalid comment in mangle postrouting rule %d", i);
+            return -1;
+        }
+    }
+
+    /* Validate routes */
+    for (int i = 0; i < cfg->route_count; i++) {
+        const fw_route_t *r = &cfg->routes[i];
+        if (r->destination[0] && !fw_validate_ipv4_cidr(r->destination) && !fw_validate_ipv4(r->destination)) {
+            snprintf(err, errlen, "invalid destination in route %d: %s", i, r->destination);
+            return -1;
+        }
+        if (r->gateway[0] && !fw_validate_ipv4(r->gateway)) {
+            snprintf(err, errlen, "invalid gateway in route %d: %s", i, r->gateway);
+            return -1;
+        }
+        if (r->interface[0] && !fw_validate_interface(r->interface)) {
+            snprintf(err, errlen, "invalid interface in route %d: %s", i, r->interface);
+            return -1;
+        }
+        if (!fw_validate_comment(r->comment)) {
+            snprintf(err, errlen, "invalid comment in route %d", i);
+            return -1;
+        }
+    }
+
+    /* Validate DPI rules */
+    for (int i = 0; i < cfg->dpi_rule_count; i++) {
+        const fw_dpi_rule_t *r = &cfg->dpi_rules[i];
+        if (!fw_validate_addr_field(r->src_addr)) {
+            snprintf(err, errlen, "invalid src_addr in DPI rule %d: %s", i, r->src_addr);
+            return -1;
+        }
+        if (!fw_validate_addr_field(r->dst_addr)) {
+            snprintf(err, errlen, "invalid dst_addr in DPI rule %d: %s", i, r->dst_addr);
+            return -1;
+        }
+        if (!fw_validate_comment(r->comment)) {
+            snprintf(err, errlen, "invalid comment in DPI rule %d", i);
+            return -1;
         }
     }
 

--- a/src/lib/config.c
+++ b/src/lib/config.c
@@ -825,6 +825,10 @@ int fw_config_validate(const fw_config_t *cfg, char *err, size_t errlen)
             snprintf(err, errlen, "invalid to_source in NAT postrouting rule %d: %s", i, r->to_source);
             return -1;
         }
+        if (!fw_validate_comment(r->comment)) {
+            snprintf(err, errlen, "invalid comment in NAT postrouting rule %d", i);
+            return -1;
+        }
     }
 
     /* Validate NAT prerouting rules */
@@ -848,6 +852,10 @@ int fw_config_validate(const fw_config_t *cfg, char *err, size_t errlen)
         }
         if (!fw_validate_port(r->to_dest_port)) {
             snprintf(err, errlen, "invalid to_dest_port in NAT prerouting rule %d: %d", i, r->to_dest_port);
+            return -1;
+        }
+        if (!fw_validate_comment(r->comment)) {
+            snprintf(err, errlen, "invalid comment in NAT prerouting rule %d", i);
             return -1;
         }
     }
@@ -890,22 +898,6 @@ int fw_config_validate(const fw_config_t *cfg, char *err, size_t errlen)
         }
     }
 
-    /* Validate NAT postrouting comments */
-    for (int i = 0; i < cfg->nat_post_count; i++) {
-        if (!fw_validate_comment(cfg->nat_post[i].comment)) {
-            snprintf(err, errlen, "invalid comment in NAT postrouting rule %d", i);
-            return -1;
-        }
-    }
-
-    /* Validate NAT prerouting comments */
-    for (int i = 0; i < cfg->nat_pre_count; i++) {
-        if (!fw_validate_comment(cfg->nat_pre[i].comment)) {
-            snprintf(err, errlen, "invalid comment in NAT prerouting rule %d", i);
-            return -1;
-        }
-    }
-
     /* Validate mangle rules */
     for (int i = 0; i < cfg->mangle_pre_count; i++) {
         const fw_mangle_rule_t *r = &cfg->mangle_pre[i];
@@ -921,7 +913,7 @@ int fw_config_validate(const fw_config_t *cfg, char *err, size_t errlen)
             snprintf(err, errlen, "invalid dst_addr in mangle prerouting rule %d: %s", i, r->dst_addr);
             return -1;
         }
-        if (r->mark[0] && !fw_validate_mark(r->mark)) {
+        if (!fw_validate_mark(r->mark)) {
             snprintf(err, errlen, "invalid mark in mangle prerouting rule %d: %s", i, r->mark);
             return -1;
         }
@@ -944,7 +936,7 @@ int fw_config_validate(const fw_config_t *cfg, char *err, size_t errlen)
             snprintf(err, errlen, "invalid dst_addr in mangle postrouting rule %d: %s", i, r->dst_addr);
             return -1;
         }
-        if (r->mark[0] && !fw_validate_mark(r->mark)) {
+        if (!fw_validate_mark(r->mark)) {
             snprintf(err, errlen, "invalid mark in mangle postrouting rule %d: %s", i, r->mark);
             return -1;
         }

--- a/src/lib/validate.c
+++ b/src/lib/validate.c
@@ -184,7 +184,7 @@ int fw_validate_addr_field(const char *addr)
 int fw_validate_mark(const char *mark)
 {
     if (!mark || !*mark)
-        return 0;
+        return 1; /* Empty/NULL is OK (optional field) */
 
     const char *p = mark;
 

--- a/src/lib/validate.c
+++ b/src/lib/validate.c
@@ -169,3 +169,41 @@ int fw_validate_comment(const char *comment)
     }
     return 1;
 }
+
+int fw_validate_addr_field(const char *addr)
+{
+    if (!addr || !*addr)
+        return 1; /* Empty/NULL is OK (optional field) */
+    if (fw_validate_ipv4(addr))
+        return 1;
+    if (fw_validate_ipv4_cidr(addr))
+        return 1;
+    return 0;
+}
+
+int fw_validate_mark(const char *mark)
+{
+    if (!mark || !*mark)
+        return 0;
+
+    const char *p = mark;
+
+    /* Allow "0x" or "0X" prefix for hex */
+    if (p[0] == '0' && (p[1] == 'x' || p[1] == 'X')) {
+        p += 2;
+        if (!*p)
+            return 0;
+        for (; *p; p++) {
+            if (!isxdigit((unsigned char)*p))
+                return 0;
+        }
+        return 1;
+    }
+
+    /* Otherwise must be decimal digits */
+    for (; *p; p++) {
+        if (!isdigit((unsigned char)*p))
+            return 0;
+    }
+    return 1;
+}

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -461,6 +461,104 @@ static void test_config_roundtrip_full(void)
     remove(tmpfile);
 }
 
+static void test_validate_filter_rule_fields(void)
+{
+    printf("test_validate_filter_rule_fields\n");
+    fw_config_t cfg;
+    char err[256] = {0};
+
+    int ret = fw_config_load("tests/fixtures/minimal.json", &cfg, err, sizeof(err));
+    ASSERT(ret == 0, "load for validate filter fields");
+
+    /* Add a filter rule with invalid src_addr */
+    int idx = fw_config_chain_index("lan2wan");
+    ASSERT(idx >= 0, "lan2wan found");
+    fw_filter_rule_t *r = &cfg.chains[idx].rules[cfg.chains[idx].rule_count];
+    memset(r, 0, sizeof(*r));
+    fw_strlcpy(r->src_addr, "999.999.999.999", sizeof(r->src_addr));
+    r->action = ACTION_ACCEPT;
+    cfg.chains[idx].rule_count++;
+
+    ret = fw_config_validate(&cfg, err, sizeof(err));
+    ASSERT(ret == -1, "validate catches invalid src_addr in filter rule");
+
+    /* Fix src_addr, set invalid comment */
+    fw_strlcpy(r->src_addr, "10.0.0.1", sizeof(r->src_addr));
+    fw_strlcpy(r->comment, "bad;comment", sizeof(r->comment));
+    ret = fw_config_validate(&cfg, err, sizeof(err));
+    ASSERT(ret == -1, "validate catches invalid comment in filter rule");
+
+    /* Fix comment, verify it passes */
+    fw_strlcpy(r->comment, "good comment", sizeof(r->comment));
+    ret = fw_config_validate(&cfg, err, sizeof(err));
+    ASSERT(ret == 0, "validate passes with valid filter rule");
+
+    /* Remove the added rule */
+    cfg.chains[idx].rule_count--;
+}
+
+static void test_validate_mangle_mark(void)
+{
+    printf("test_validate_mangle_mark\n");
+    fw_config_t cfg;
+    char err[256] = {0};
+
+    int ret = fw_config_load("tests/fixtures/minimal.json", &cfg, err, sizeof(err));
+    ASSERT(ret == 0, "load for validate mangle mark");
+
+    /* Add a mangle prerouting rule with invalid mark */
+    fw_mangle_rule_t *r = &cfg.mangle_pre[cfg.mangle_pre_count];
+    memset(r, 0, sizeof(*r));
+    fw_strlcpy(r->iif, "eth0", sizeof(r->iif));
+    fw_strlcpy(r->mark, "invalid!mark", sizeof(r->mark));
+    r->protocol = PROTO_TCP;
+    cfg.mangle_pre_count++;
+
+    ret = fw_config_validate(&cfg, err, sizeof(err));
+    ASSERT(ret == -1, "validate catches invalid mangle mark");
+
+    /* Fix mark to valid hex, should pass */
+    fw_strlcpy(r->mark, "0xFF", sizeof(r->mark));
+    ret = fw_config_validate(&cfg, err, sizeof(err));
+    ASSERT(ret == 0, "validate passes with valid hex mark");
+
+    /* Empty mark should also pass (optional) */
+    r->mark[0] = '\0';
+    ret = fw_config_validate(&cfg, err, sizeof(err));
+    ASSERT(ret == 0, "validate passes with empty mark");
+
+    cfg.mangle_pre_count--;
+}
+
+static void test_validate_nat_comment(void)
+{
+    printf("test_validate_nat_comment\n");
+    fw_config_t cfg;
+    char err[256] = {0};
+
+    int ret = fw_config_load("tests/fixtures/minimal.json", &cfg, err, sizeof(err));
+    ASSERT(ret == 0, "load for validate nat comment");
+
+    /* Add a NAT postrouting rule with invalid comment */
+    fw_nat_post_t *r = &cfg.nat_post[cfg.nat_post_count];
+    memset(r, 0, sizeof(*r));
+    fw_strlcpy(r->src, "192.168.1.0/24", sizeof(r->src));
+    fw_strlcpy(r->oif, "eth1", sizeof(r->oif));
+    r->type = NAT_MASQUERADE;
+    fw_strlcpy(r->comment, "drop;table", sizeof(r->comment));
+    cfg.nat_post_count++;
+
+    ret = fw_config_validate(&cfg, err, sizeof(err));
+    ASSERT(ret == -1, "validate catches invalid NAT postrouting comment");
+
+    /* Fix comment */
+    fw_strlcpy(r->comment, "masquerade rule", sizeof(r->comment));
+    ret = fw_config_validate(&cfg, err, sizeof(err));
+    ASSERT(ret == 0, "validate passes with valid NAT postrouting comment");
+
+    cfg.nat_post_count--;
+}
+
 int main(void)
 {
     printf("=== Config Tests ===\n\n");
@@ -479,6 +577,9 @@ int main(void)
     test_set_chain_ports();
     test_set_nat();
     test_config_roundtrip_full();
+    test_validate_filter_rule_fields();
+    test_validate_mangle_mark();
+    test_validate_nat_comment();
 
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return tests_passed == tests_run ? 0 : 1;

--- a/tests/test_validate.c
+++ b/tests/test_validate.c
@@ -132,6 +132,55 @@ static void test_comment(void)
     ASSERT(fw_validate_comment("rule`cmd`") == 0, "backtick");
 }
 
+static void test_addr_field(void)
+{
+    printf("test_addr_field\n");
+    /* NULL and empty are valid (optional field) */
+    ASSERT(fw_validate_addr_field(NULL) == 1, "null ok");
+    ASSERT(fw_validate_addr_field("") == 1, "empty ok");
+
+    /* Valid IPv4 addresses */
+    ASSERT(fw_validate_addr_field("192.168.1.1") == 1, "valid ipv4");
+    ASSERT(fw_validate_addr_field("10.0.0.1") == 1, "valid 10.x");
+
+    /* Valid CIDR */
+    ASSERT(fw_validate_addr_field("192.168.1.0/24") == 1, "valid cidr");
+    ASSERT(fw_validate_addr_field("10.0.0.0/8") == 1, "valid /8 cidr");
+
+    /* Invalid */
+    ASSERT(fw_validate_addr_field("999.999.999.999") == 0, "invalid ip");
+    ASSERT(fw_validate_addr_field("abc") == 0, "letters");
+    ASSERT(fw_validate_addr_field("192.168.1.0/33") == 0, "bad cidr mask");
+    ASSERT(fw_validate_addr_field("192.168.1") == 0, "incomplete ip");
+}
+
+static void test_mark(void)
+{
+    printf("test_mark\n");
+    /* NULL and empty are valid (optional field) */
+    ASSERT(fw_validate_mark(NULL) == 1, "null ok");
+    ASSERT(fw_validate_mark("") == 1, "empty ok");
+
+    /* Valid decimal */
+    ASSERT(fw_validate_mark("0") == 1, "zero");
+    ASSERT(fw_validate_mark("1") == 1, "one");
+    ASSERT(fw_validate_mark("42") == 1, "decimal 42");
+    ASSERT(fw_validate_mark("65535") == 1, "large decimal");
+
+    /* Valid hex */
+    ASSERT(fw_validate_mark("0x1") == 1, "hex 0x1");
+    ASSERT(fw_validate_mark("0xFF") == 1, "hex 0xFF");
+    ASSERT(fw_validate_mark("0X10") == 1, "hex 0X10");
+    ASSERT(fw_validate_mark("0xDEAD") == 1, "hex 0xDEAD");
+
+    /* Invalid */
+    ASSERT(fw_validate_mark("abc") == 0, "bare letters");
+    ASSERT(fw_validate_mark("0x") == 0, "hex prefix only");
+    ASSERT(fw_validate_mark("0xGG") == 0, "invalid hex digits");
+    ASSERT(fw_validate_mark("-1") == 0, "negative");
+    ASSERT(fw_validate_mark("12abc") == 0, "mixed decimal/letters");
+}
+
 int main(void)
 {
     printf("=== Validator Tests ===\n\n");
@@ -144,6 +193,8 @@ int main(void)
     test_protocol();
     test_action();
     test_comment();
+    test_addr_field();
+    test_mark();
 
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return tests_passed == tests_run ? 0 : 1;


### PR DESCRIPTION
## Task SEC-003 — Validate interface names and config fields against injection

### Summary
- Extended `fw_config_validate()` with validation for all fields flowing into shell commands
- Added `fw_validate_addr_field()` (IPv4/CIDR validation) and `fw_validate_mark()` (decimal/hex)
- Validates: filter rule addresses/comments, NAT comments, mangle rules (iif, addresses, marks), routes, DPI rules

### Related Issue
Refs #11 (SEC-003)

---
*Generated by Claude Code via `/task-pick`*