### PR TITLE
[SEC-006] Replace predictable temp files with mkstemp() to prevent TOCTOU

### DIFF
--- a/include/firewallo/config.h
+++ b/include/firewallo/config.h
@@ -13,6 +13,10 @@ int fw_config_load(const char *path, fw_config_t *cfg, char *err, size_t errlen)
 /* Save config to JSON file. Returns 0 on success. */
 int fw_config_save(const char *path, const fw_config_t *cfg);
 
+/* Serialize config to a JSON string. Returns malloc'd string or NULL on error.
+ * Caller must free() the returned string. */
+char *fw_config_serialize(const fw_config_t *cfg);
+
 /* Validate a loaded config. Returns 0 if valid, -1 if invalid (error in err). */
 int fw_config_validate(const fw_config_t *cfg, char *err, size_t errlen);
 

--- a/src/lib/config.c
+++ b/src/lib/config.c
@@ -633,9 +633,9 @@ static json_value_t *build_routes_array(const fw_route_t *routes, int count)
     return arr;
 }
 
-/* ── Save ──────────────────────────────────────────────────────────── */
+/* ── Serialize ─────────────────────────────────────────────────────── */
 
-int fw_config_save(const char *path, const fw_config_t *cfg)
+static json_value_t *config_to_json(const fw_config_t *cfg)
 {
     json_value_t *root = json_new_object();
 
@@ -735,10 +735,24 @@ int fw_config_save(const char *path, const fw_config_t *cfg)
                                        cfg->suricata_blocked_count));
     json_object_set(root, "suricata", suricata);
 
-    /* Serialize and write */
+    return root;
+}
+
+char *fw_config_serialize(const fw_config_t *cfg)
+{
+    json_value_t *root = config_to_json(cfg);
+    if (!root)
+        return NULL;
     char *json_str = json_serialize(root, 1);
     json_free(root);
+    return json_str;
+}
 
+/* ── Save ──────────────────────────────────────────────────────────── */
+
+int fw_config_save(const char *path, const fw_config_t *cfg)
+{
+    char *json_str = fw_config_serialize(cfg);
     if (!json_str)
         return -1;
 

--- a/src/lib/util.c
+++ b/src/lib/util.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <unistd.h>
+#include <sys/stat.h>
 
 size_t fw_strlcpy(char *dst, const char *src, size_t size)
 {
@@ -53,21 +54,49 @@ char *fw_read_file(const char *path, size_t *out_len)
 
 int fw_write_file(const char *path, const char *data, size_t len)
 {
-    /* Write to a temporary file, then rename for atomicity */
+    /*
+     * Write to a mkstemp-created temp file in the same directory, then
+     * rename for atomicity.  This avoids predictable temp-file names
+     * (e.g. "%s.tmp") that are vulnerable to symlink attacks in
+     * world-writable directories such as /tmp.
+     */
+
+    /* Build template in the same directory as the target path */
     char tmp[512];
-    snprintf(tmp, sizeof(tmp), "%s.tmp", path);
-
-    FILE *f = fopen(tmp, "wb");
-    if (!f)
-        return -1;
-
-    size_t written = fwrite(data, 1, len, f);
-    fclose(f);
-
-    if (written != len) {
-        unlink(tmp);
-        return -1;
+    const char *last_slash = strrchr(path, '/');
+    if (last_slash) {
+        size_t dir_len = (size_t)(last_slash - path + 1);
+        if (dir_len + sizeof(".fw_XXXXXX") > sizeof(tmp))
+            return -1;
+        memcpy(tmp, path, dir_len);
+        memcpy(tmp + dir_len, ".fw_XXXXXX", sizeof(".fw_XXXXXX"));
+    } else {
+        /* No directory component — use current directory */
+        memcpy(tmp, ".fw_XXXXXX", sizeof(".fw_XXXXXX"));
     }
+
+    int fd = mkstemp(tmp);  /* creates with mode 0600, O_EXCL semantics */
+    if (fd < 0)
+        return -1;
+
+    /* Preserve target file permissions when possible */
+    struct stat st;
+    if (stat(path, &st) == 0)
+        fchmod(fd, st.st_mode & 0777);
+
+    const char *p = data;
+    size_t remaining = len;
+    while (remaining > 0) {
+        ssize_t written = write(fd, p, remaining);
+        if (written < 0) {
+            close(fd);
+            unlink(tmp);
+            return -1;
+        }
+        p += written;
+        remaining -= (size_t)written;
+    }
+    close(fd);
 
     if (rename(tmp, path) != 0) {
         unlink(tmp);

--- a/src/web/api.c
+++ b/src/web/api.c
@@ -71,24 +71,10 @@ static void api_version(httpd_t *srv, http_response_t *resp)
 
 static void api_get_config(httpd_t *srv, http_response_t *resp)
 {
-    /* Serialize config via mkstemp to avoid predictable temp file paths */
-    char tmp[] = "/tmp/.firewallo_api_XXXXXX";
-    int fd = mkstemp(tmp);
-    if (fd < 0) {
-        api_error(resp, 500, "Failed to create temp file");
-        return;
-    }
-    close(fd);
-    if (fw_config_save(tmp, srv->config) != 0) {
-        unlink(tmp);
-        api_error(resp, 500, "Serialization failed");
-        return;
-    }
-    size_t len;
-    char *json = fw_read_file(tmp, &len);
-    unlink(tmp);
+    /* Serialize config directly to memory — no temp files needed */
+    char *json = fw_config_serialize(srv->config);
     if (!json) {
-        api_error(resp, 500, "Read failed");
+        api_error(resp, 500, "Serialization failed");
         return;
     }
 
@@ -110,15 +96,17 @@ static void api_put_config(httpd_t *srv, const http_request_t *req, http_respons
         return;
     }
 
-    /* Write body to mkstemp temp file to avoid predictable paths (TOCTOU) */
+    /* Write body directly to mkstemp fd to avoid predictable temp paths (TOCTOU) */
     char tmp[] = "/tmp/.firewallo_api_XXXXXX";
     int fd = mkstemp(tmp);
     if (fd < 0) {
         api_error(resp, 500, "Failed to create temp file");
         return;
     }
+
+    ssize_t written = write(fd, req->body, req->body_len);
     close(fd);
-    if (fw_write_file(tmp, req->body, req->body_len) != 0) {
+    if (written < 0 || (size_t)written != req->body_len) {
         unlink(tmp);
         api_error(resp, 500, "Write failed");
         return;

--- a/src/web/api.c
+++ b/src/web/api.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 /* ── Helpers ───────────────────────────────────────────────────────── */
 
@@ -70,15 +71,22 @@ static void api_version(httpd_t *srv, http_response_t *resp)
 
 static void api_get_config(httpd_t *srv, http_response_t *resp)
 {
-    /* Serialize the entire config */
-    const char *tmp = "/tmp/.firewallo_api_cfg.json";
+    /* Serialize config via mkstemp to avoid predictable temp file paths */
+    char tmp[] = "/tmp/.firewallo_api_XXXXXX";
+    int fd = mkstemp(tmp);
+    if (fd < 0) {
+        api_error(resp, 500, "Failed to create temp file");
+        return;
+    }
+    close(fd);
     if (fw_config_save(tmp, srv->config) != 0) {
+        unlink(tmp);
         api_error(resp, 500, "Serialization failed");
         return;
     }
     size_t len;
     char *json = fw_read_file(tmp, &len);
-    remove(tmp);
+    unlink(tmp);
     if (!json) {
         api_error(resp, 500, "Read failed");
         return;
@@ -102,9 +110,16 @@ static void api_put_config(httpd_t *srv, const http_request_t *req, http_respons
         return;
     }
 
-    /* Write body to temp, load as config */
-    const char *tmp = "/tmp/.firewallo_api_put.json";
+    /* Write body to mkstemp temp file to avoid predictable paths (TOCTOU) */
+    char tmp[] = "/tmp/.firewallo_api_XXXXXX";
+    int fd = mkstemp(tmp);
+    if (fd < 0) {
+        api_error(resp, 500, "Failed to create temp file");
+        return;
+    }
+    close(fd);
     if (fw_write_file(tmp, req->body, req->body_len) != 0) {
+        unlink(tmp);
         api_error(resp, 500, "Write failed");
         return;
     }
@@ -112,11 +127,11 @@ static void api_put_config(httpd_t *srv, const http_request_t *req, http_respons
     fw_config_t new_cfg;
     char err[256];
     if (fw_config_load(tmp, &new_cfg, err, sizeof(err)) != 0) {
-        remove(tmp);
+        unlink(tmp);
         api_error(resp, 400, err);
         return;
     }
-    remove(tmp);
+    unlink(tmp);
 
     if (fw_config_validate(&new_cfg, err, sizeof(err)) != 0) {
         api_error(resp, 400, err);


### PR DESCRIPTION
## Task SEC-006 — Replace predictable temp files with mkstemp() to prevent TOCTOU

### Summary
- Replaced hardcoded `/tmp/.firewallo_api_cfg.json` and `/tmp/.firewallo_api_put.json` with `mkstemp()` calls
- Temp files now have unique, unpredictable names and are created atomically with mode 0600
- Added proper cleanup on error paths to avoid leaking temp files

### Related Issue
Refs #14 (SEC-006)

---
*Generated by Claude Code via `/task-pick`*