### PR TITLE
[SEC-008] Add fork-per-connection to mitigate DoS from slow clients

### DIFF
--- a/src/web/httpd.c
+++ b/src/web/httpd.c
@@ -12,6 +12,24 @@
 #include <poll.h>
 #include <signal.h>
 #include <errno.h>
+#include <sys/wait.h>
+
+/* ── Fork-per-connection constants ───────────────────────────────── */
+
+#define HTTPD_MAX_CHILDREN      16   /* Max concurrent child processes */
+#define HTTPD_READ_TIMEOUT_MS   2000 /* Per-read poll timeout (ms)     */
+#define HTTPD_CONN_TIMEOUT_SEC  10   /* Max total connection time (s)  */
+
+static volatile sig_atomic_t g_active_children = 0;
+
+static void sigchld_handler(int sig)
+{
+    (void)sig;
+    int saved_errno = errno;
+    while (waitpid(-1, NULL, WNOHANG) > 0)
+        g_active_children--;
+    errno = saved_errno;
+}
 
 /* ── Response helpers ──────────────────────────────────────────────── */
 
@@ -204,7 +222,7 @@ static void handle_connection(httpd_t *srv, int client_fd)
     /* Read request with poll timeout */
     struct pollfd pfd = {.fd = client_fd, .events = POLLIN};
     while ((size_t)total < sizeof(buf) - 1) {
-        int ready = poll(&pfd, 1, 5000); /* 5 second timeout */
+        int ready = poll(&pfd, 1, HTTPD_READ_TIMEOUT_MS);
         if (ready <= 0) break;
 
         ssize_t n = read(client_fd, buf + total, sizeof(buf) - 1 - (size_t)total);
@@ -311,12 +329,19 @@ int httpd_init(httpd_t *srv, const char *bind_addr, int port,
     return 0;
 }
 
-/* ── Server main loop ──────────────────────────────────────────────── */
+/* ── Server main loop (fork-per-connection) ───────────────────────── */
 
 int httpd_run(httpd_t *srv)
 {
     fw_log(LOG_INFO, "firewallo-web listening on %s:%d",
            srv->bind_addr ? srv->bind_addr : "0.0.0.0", srv->port);
+
+    /* Install SIGCHLD handler to reap child processes */
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sigchld_handler;
+    sa.sa_flags = SA_RESTART | SA_NOCLDSTOP;
+    sigaction(SIGCHLD, &sa, NULL);
 
     struct pollfd pfd = {.fd = srv->listen_fd, .events = POLLIN};
 
@@ -339,10 +364,47 @@ int httpd_run(httpd_t *srv)
             continue;
         }
 
-        handle_connection(srv, client_fd);
+        /* Reject new connections when at capacity */
+        if (g_active_children >= HTTPD_MAX_CHILDREN) {
+            fw_log(LOG_WARN, "Max children (%d) reached, rejecting connection",
+                   HTTPD_MAX_CHILDREN);
+            close(client_fd);
+            continue;
+        }
+
+        pid_t pid = fork();
+        if (pid < 0) {
+            perror("fork");
+            close(client_fd);
+            continue;
+        }
+
+        if (pid == 0) {
+            /* ── Child process ────────────────────────────────── */
+            close(srv->listen_fd);
+
+            /* Hard limit on total connection time */
+            alarm(HTTPD_CONN_TIMEOUT_SEC);
+
+            handle_connection(srv, client_fd);
+            _exit(0);
+        }
+
+        /* ── Parent process ───────────────────────────────────── */
+        g_active_children++;
+        close(client_fd);
     }
 
     close(srv->listen_fd);
+
+    /* Wait for remaining children before exit */
+    while (g_active_children > 0) {
+        if (waitpid(-1, NULL, 0) > 0)
+            g_active_children--;
+        else
+            break;
+    }
+
     return 0;
 }
 

--- a/src/web/httpd.c
+++ b/src/web/httpd.c
@@ -21,14 +21,22 @@
 #define HTTPD_CONN_TIMEOUT_SEC  10   /* Max total connection time (s)  */
 
 static volatile sig_atomic_t g_active_children = 0;
+static volatile sig_atomic_t g_sigchld_fired = 0;
 
 static void sigchld_handler(int sig)
 {
     (void)sig;
-    int saved_errno = errno;
-    while (waitpid(-1, NULL, WNOHANG) > 0)
-        g_active_children--;
-    errno = saved_errno;
+    g_sigchld_fired = 1;
+}
+
+/* Reap finished children and update counter (call with SIGCHLD blocked) */
+static void reap_children(void)
+{
+    while (waitpid(-1, NULL, WNOHANG) > 0) {
+        if (g_active_children > 0)
+            g_active_children--;
+    }
+    g_sigchld_fired = 0;
 }
 
 /* ── Response helpers ──────────────────────────────────────────────── */
@@ -336,29 +344,54 @@ int httpd_run(httpd_t *srv)
     fw_log(LOG_INFO, "firewallo-web listening on %s:%d",
            srv->bind_addr ? srv->bind_addr : "0.0.0.0", srv->port);
 
-    /* Install SIGCHLD handler to reap child processes */
+    /* Install SIGCHLD handler to set reap flag */
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = sigchld_handler;
+    sigemptyset(&sa.sa_mask);
     sa.sa_flags = SA_RESTART | SA_NOCLDSTOP;
-    sigaction(SIGCHLD, &sa, NULL);
+    if (sigaction(SIGCHLD, &sa, NULL) < 0) {
+        perror("sigaction");
+        return -1;
+    }
+
+    /* Prepare signal mask for critical sections */
+    sigset_t block_chld, prev_mask;
+    sigemptyset(&block_chld);
+    sigaddset(&block_chld, SIGCHLD);
 
     struct pollfd pfd = {.fd = srv->listen_fd, .events = POLLIN};
 
     while (srv->running) {
         int ready = poll(&pfd, 1, 1000);
         if (ready < 0) {
-            if (errno == EINTR) continue;
+            if (errno == EINTR) {
+                /* Reap outside critical section is fine here —
+                   we'll reap again inside the critical section below */
+                continue;
+            }
             perror("poll");
             break;
         }
-        if (ready == 0) continue;
+
+        /* Block SIGCHLD for reaping + capacity check + fork + increment */
+        sigprocmask(SIG_BLOCK, &block_chld, &prev_mask);
+
+        /* Reap any finished children */
+        if (g_sigchld_fired)
+            reap_children();
+
+        if (ready == 0) {
+            sigprocmask(SIG_SETMASK, &prev_mask, NULL);
+            continue;
+        }
 
         struct sockaddr_in client_addr;
         socklen_t client_len = sizeof(client_addr);
         int client_fd = accept(srv->listen_fd,
                                (struct sockaddr *)&client_addr, &client_len);
         if (client_fd < 0) {
+            sigprocmask(SIG_SETMASK, &prev_mask, NULL);
             if (errno == EINTR) continue;
             perror("accept");
             continue;
@@ -369,6 +402,7 @@ int httpd_run(httpd_t *srv)
             fw_log(LOG_WARN, "Max children (%d) reached, rejecting connection",
                    HTTPD_MAX_CHILDREN);
             close(client_fd);
+            sigprocmask(SIG_SETMASK, &prev_mask, NULL);
             continue;
         }
 
@@ -376,11 +410,13 @@ int httpd_run(httpd_t *srv)
         if (pid < 0) {
             perror("fork");
             close(client_fd);
+            sigprocmask(SIG_SETMASK, &prev_mask, NULL);
             continue;
         }
 
         if (pid == 0) {
             /* ── Child process ────────────────────────────────── */
+            sigprocmask(SIG_SETMASK, &prev_mask, NULL);
             close(srv->listen_fd);
 
             /* Hard limit on total connection time */
@@ -392,17 +428,21 @@ int httpd_run(httpd_t *srv)
 
         /* ── Parent process ───────────────────────────────────── */
         g_active_children++;
+        sigprocmask(SIG_SETMASK, &prev_mask, NULL);
         close(client_fd);
     }
 
     close(srv->listen_fd);
 
     /* Wait for remaining children before exit */
-    while (g_active_children > 0) {
-        if (waitpid(-1, NULL, 0) > 0)
-            g_active_children--;
-        else
-            break;
+    for (;;) {
+        pid_t w = waitpid(-1, NULL, 0);
+        if (w > 0)
+            continue;
+        if (w < 0 && errno == EINTR)
+            continue;
+        /* ECHILD or other error — no more children */
+        break;
     }
 
     return 0;


### PR DESCRIPTION
## Task SEC-008 — Add fork-per-connection to mitigate DoS from slow clients

### Summary
- Implemented fork-per-connection model so slow clients cannot block others
- Max 16 concurrent child processes (new connections rejected when limit reached)
- SIGCHLD handler reaps terminated children to prevent zombies
- Reduced read timeout from 5000ms to 2000ms
- Added 10-second hard connection deadline via `alarm()` per child

### Related Issue
Refs #16 (SEC-008)

---
*Generated by Claude Code via `/task-pick`*