### PR TITLE
[SEC-009] Properly escape API error messages to prevent JSON injection

### DIFF
--- a/src/web/api.c
+++ b/src/web/api.c
@@ -12,12 +12,13 @@
 
 /* ── Helpers ───────────────────────────────────────────────────────── */
 
+static const char API_ERR_FALLBACK[] = "{\"error\":true,\"message\":\"internal error\"}";
+
 static void api_error(http_response_t *resp, int status, const char *msg)
 {
     json_value_t *envelope = json_new_object();
     if (!envelope) {
-        http_response_set_json(resp, status,
-            strdup("{\"error\":true,\"message\":\"internal error\"}"));
+        http_response_set_json(resp, status, strdup(API_ERR_FALLBACK));
         return;
     }
 
@@ -28,15 +29,13 @@ static void api_error(http_response_t *resp, int status, const char *msg)
         json_free(err_val);
         json_free(msg_val);
         json_free(envelope);
-        http_response_set_json(resp, status,
-            strdup("{\"error\":true,\"message\":\"internal error\"}"));
+        http_response_set_json(resp, status, strdup(API_ERR_FALLBACK));
         return;
     }
     if (json_object_set(envelope, "message", msg_val) != 0) {
         json_free(msg_val);
         json_free(envelope);
-        http_response_set_json(resp, status,
-            strdup("{\"error\":true,\"message\":\"internal error\"}"));
+        http_response_set_json(resp, status, strdup(API_ERR_FALLBACK));
         return;
     }
 
@@ -44,8 +43,7 @@ static void api_error(http_response_t *resp, int status, const char *msg)
     json_free(envelope);
 
     if (!json) {
-        http_response_set_json(resp, status,
-            strdup("{\"error\":true,\"message\":\"internal error\"}"));
+        http_response_set_json(resp, status, strdup(API_ERR_FALLBACK));
         return;
     }
     http_response_set_json(resp, status, json);

--- a/src/web/api.c
+++ b/src/web/api.c
@@ -15,10 +15,39 @@
 static void api_error(http_response_t *resp, int status, const char *msg)
 {
     json_value_t *envelope = json_new_object();
-    json_object_set(envelope, "error", json_new_bool(1));
-    json_object_set(envelope, "message", json_new_string(msg));
-    char *json = json_serialize(envelope, 0);
+    if (!envelope) {
+        http_response_set_json(resp, status,
+            strdup("{\"error\":true,\"message\":\"internal error\"}"));
+        return;
+    }
+
+    json_value_t *err_val = json_new_bool(1);
+    json_value_t *msg_val = json_new_string(msg);
+
+    if (json_object_set(envelope, "error", err_val) != 0) {
+        json_free(err_val);
+        json_free(msg_val);
+        json_free(envelope);
+        http_response_set_json(resp, status,
+            strdup("{\"error\":true,\"message\":\"internal error\"}"));
+        return;
+    }
+    if (json_object_set(envelope, "message", msg_val) != 0) {
+        json_free(msg_val);
+        json_free(envelope);
+        http_response_set_json(resp, status,
+            strdup("{\"error\":true,\"message\":\"internal error\"}"));
+        return;
+    }
+
+    char *json = json_serialize(envelope, 1);
     json_free(envelope);
+
+    if (!json) {
+        http_response_set_json(resp, status,
+            strdup("{\"error\":true,\"message\":\"internal error\"}"));
+        return;
+    }
     http_response_set_json(resp, status, json);
 }
 

--- a/src/web/api.c
+++ b/src/web/api.c
@@ -14,9 +14,12 @@
 
 static void api_error(http_response_t *resp, int status, const char *msg)
 {
-    char *buf = malloc(256);
-    snprintf(buf, 256, "{\"error\":true,\"message\":\"%s\"}", msg);
-    http_response_set_json(resp, status, buf);
+    json_value_t *envelope = json_new_object();
+    json_object_set(envelope, "error", json_new_bool(1));
+    json_object_set(envelope, "message", json_new_string(msg));
+    char *json = json_serialize(envelope, 0);
+    json_free(envelope);
+    http_response_set_json(resp, status, json);
 }
 
 static void api_ok_json(http_response_t *resp, json_value_t *data)


### PR DESCRIPTION
## Task SEC-009 — Properly escape API error messages to prevent JSON injection

### Summary
- Replaced raw `snprintf` JSON construction in `api_error()` with the project's JSON builder API
- Uses `json_new_object()`, `json_object_set()`, `json_new_string()`, `json_serialize()` for proper escaping
- Follows the same pattern already used by `api_ok_msg()` and `api_ok_json()`

### Related Issue
Refs #17 (SEC-009)

---
*Generated by Claude Code via `/task-pick`*