### PR TITLE
[SEC-010] Replace atoi() with validated strtol() for URL port parsing

### DIFF
--- a/src/web/api.c
+++ b/src/web/api.c
@@ -575,8 +575,8 @@ int api_handle(httpd_t *srv, const http_request_t *req, http_response_t *resp)
         if ((port_str = path_after(resource, "tcp/")) != NULL && strcmp(method, "DELETE") == 0) {
             char *endptr;
             long port_val = strtol(port_str, &endptr, 10);
-            if (*endptr != '\0' || endptr == port_str || port_val < 1 || port_val > 65535) {
-                api_error(resp, 400, "Invalid port number (must be 1-65535)");
+            if (*endptr != '\0' || endptr == port_str || !fw_validate_port((int)port_val)) {
+                api_error(resp, 400, "Invalid port (1-65535)");
                 return 0;
             }
             api_delete_port(srv, chain_name, (int)port_val, 1, resp);
@@ -585,8 +585,8 @@ int api_handle(httpd_t *srv, const http_request_t *req, http_response_t *resp)
         if ((port_str = path_after(resource, "udp/")) != NULL && strcmp(method, "DELETE") == 0) {
             char *endptr;
             long port_val = strtol(port_str, &endptr, 10);
-            if (*endptr != '\0' || endptr == port_str || port_val < 1 || port_val > 65535) {
-                api_error(resp, 400, "Invalid port number (must be 1-65535)");
+            if (*endptr != '\0' || endptr == port_str || !fw_validate_port((int)port_val)) {
+                api_error(resp, 400, "Invalid port (1-65535)");
                 return 0;
             }
             api_delete_port(srv, chain_name, (int)port_val, 0, resp);

--- a/src/web/api.c
+++ b/src/web/api.c
@@ -575,7 +575,11 @@ int api_handle(httpd_t *srv, const http_request_t *req, http_response_t *resp)
         if ((port_str = path_after(resource, "tcp/")) != NULL && strcmp(method, "DELETE") == 0) {
             char *endptr;
             long port_val = strtol(port_str, &endptr, 10);
-            if (*endptr != '\0' || endptr == port_str || !fw_validate_port((int)port_val)) {
+            if (*endptr != '\0' || endptr == port_str) {
+                api_error(resp, 400, "Invalid port number");
+                return 0;
+            }
+            if (!fw_validate_port((int)port_val)) {
                 api_error(resp, 400, "Invalid port (1-65535)");
                 return 0;
             }
@@ -585,7 +589,11 @@ int api_handle(httpd_t *srv, const http_request_t *req, http_response_t *resp)
         if ((port_str = path_after(resource, "udp/")) != NULL && strcmp(method, "DELETE") == 0) {
             char *endptr;
             long port_val = strtol(port_str, &endptr, 10);
-            if (*endptr != '\0' || endptr == port_str || !fw_validate_port((int)port_val)) {
+            if (*endptr != '\0' || endptr == port_str) {
+                api_error(resp, 400, "Invalid port number");
+                return 0;
+            }
+            if (!fw_validate_port((int)port_val)) {
                 api_error(resp, 400, "Invalid port (1-65535)");
                 return 0;
             }

--- a/src/web/api.c
+++ b/src/web/api.c
@@ -573,11 +573,23 @@ int api_handle(httpd_t *srv, const http_request_t *req, http_response_t *resp)
         /* DELETE /api/v1/filter/{chain}/tcp/{port} */
         const char *port_str;
         if ((port_str = path_after(resource, "tcp/")) != NULL && strcmp(method, "DELETE") == 0) {
-            api_delete_port(srv, chain_name, atoi(port_str), 1, resp);
+            char *endptr;
+            long port_val = strtol(port_str, &endptr, 10);
+            if (*endptr != '\0' || endptr == port_str || port_val < 1 || port_val > 65535) {
+                api_error(resp, 400, "Invalid port number (must be 1-65535)");
+                return 0;
+            }
+            api_delete_port(srv, chain_name, (int)port_val, 1, resp);
             return 0;
         }
         if ((port_str = path_after(resource, "udp/")) != NULL && strcmp(method, "DELETE") == 0) {
-            api_delete_port(srv, chain_name, atoi(port_str), 0, resp);
+            char *endptr;
+            long port_val = strtol(port_str, &endptr, 10);
+            if (*endptr != '\0' || endptr == port_str || port_val < 1 || port_val > 65535) {
+                api_error(resp, 400, "Invalid port number (must be 1-65535)");
+                return 0;
+            }
+            api_delete_port(srv, chain_name, (int)port_val, 0, resp);
             return 0;
         }
     }


### PR DESCRIPTION
## Task SEC-010 — Replace atoi() with validated strtol() for URL port parsing

### Summary
- Replaced `atoi()` with `strtol()` + full error checking in DELETE port handlers
- Validates: string fully consumed, not empty, port range 1-65535
- Returns HTTP 400 with descriptive error for invalid port values

### Related Issue
Refs #18 (SEC-010)

---
*Generated by Claude Code via `/task-pick`*