### PR TITLE
[SEC-011] Add TLS warning and document reverse proxy requirement

### DIFF
--- a/src/web/httpd.c
+++ b/src/web/httpd.c
@@ -396,15 +396,19 @@ int httpd_run(httpd_t *srv)
     fw_log(LOG_INFO, "firewallo-web listening on %s:%d",
            srv->bind_addr ? srv->bind_addr : "0.0.0.0", srv->port);
 
-    /* SEC-011: Warn that the server has no TLS support */
-    fw_log(LOG_WARN,
-           "WARNING: Server is running plain HTTP without TLS encryption.");
-    fw_log(LOG_WARN,
-           "All traffic is transmitted in cleartext. Do NOT expose this "
-           "server directly to untrusted networks.");
-    fw_log(LOG_WARN,
-           "For production use, place behind a TLS reverse proxy "
-           "(nginx, Caddy, HAProxy) and bind to 127.0.0.1 (-b 127.0.0.1).");
+    /* SEC-011: Consolidated TLS / bind-address warning */
+    if (srv->bind_addr && strcmp(srv->bind_addr, "0.0.0.0") == 0) {
+        fw_log(LOG_WARN,
+               "Listening on 0.0.0.0 over plain HTTP (no TLS). "
+               "The server is reachable from all interfaces in cleartext. "
+               "Use -b 127.0.0.1 with a TLS reverse proxy (nginx/Caddy/HAProxy) "
+               "for production.");
+    } else {
+        fw_log(LOG_WARN,
+               "Listening over plain HTTP (no TLS). "
+               "Place behind a TLS reverse proxy (nginx/Caddy/HAProxy) "
+               "for production.");
+    }
 
     /* Install SIGCHLD handler to set reap flag */
     struct sigaction sa;

--- a/src/web/httpd.c
+++ b/src/web/httpd.c
@@ -396,19 +396,14 @@ int httpd_run(httpd_t *srv)
     fw_log(LOG_INFO, "firewallo-web listening on %s:%d",
            srv->bind_addr ? srv->bind_addr : "0.0.0.0", srv->port);
 
-    /* SEC-011: Consolidated TLS / bind-address warning */
-    if (srv->bind_addr && strcmp(srv->bind_addr, "0.0.0.0") == 0) {
-        fw_log(LOG_WARN,
-               "Listening on 0.0.0.0 over plain HTTP (no TLS). "
-               "The server is reachable from all interfaces in cleartext. "
-               "Use -b 127.0.0.1 with a TLS reverse proxy (nginx/Caddy/HAProxy) "
-               "for production.");
-    } else {
-        fw_log(LOG_WARN,
-               "Listening over plain HTTP (no TLS). "
-               "Place behind a TLS reverse proxy (nginx/Caddy/HAProxy) "
-               "for production.");
-    }
+    /* SEC-011: Single consolidated TLS / bind-address startup warning */
+    const char *addr = srv->bind_addr ? srv->bind_addr : "0.0.0.0";
+    int exposed = (strcmp(addr, "0.0.0.0") == 0);
+    fw_log(LOG_WARN,
+           "Listening on %s:%d over plain HTTP (no TLS).%s "
+           "Place behind a TLS reverse proxy (nginx/Caddy/HAProxy) for production.",
+           addr, srv->port,
+           exposed ? " Server is reachable from all interfaces in cleartext." : "");
 
     /* Install SIGCHLD handler to set reap flag */
     struct sigaction sa;

--- a/src/web/httpd.c
+++ b/src/web/httpd.c
@@ -313,6 +313,28 @@ static void handle_connection(httpd_t *srv, int client_fd)
     close(client_fd);
 }
 
+/*
+ * ── TLS / Transport Security Notice ────────────────────────────────
+ *
+ * This HTTP server does NOT support TLS.  All traffic is transmitted in
+ * cleartext.  In production deployments the server MUST be placed behind
+ * a TLS-terminating reverse proxy such as nginx, Caddy, or HAProxy.
+ *
+ * Example (nginx):
+ *   server {
+ *       listen 443 ssl;
+ *       ssl_certificate     /etc/ssl/certs/firewallo.pem;
+ *       ssl_certificate_key /etc/ssl/private/firewallo.key;
+ *       location / { proxy_pass http://127.0.0.1:8080; }
+ *   }
+ *
+ * Bind the server to 127.0.0.1 (-b 127.0.0.1) so it is only reachable
+ * through the reverse proxy and not directly from the network.
+ *
+ * Adding native TLS would require an external library (OpenSSL, mbedTLS)
+ * which conflicts with the project's "no external dependencies" policy.
+ * ─────────────────────────────────────────────────────────────────── */
+
 /* ── Server init ───────────────────────────────────────────────────── */
 
 int httpd_init(httpd_t *srv, const char *bind_addr, int port,
@@ -373,6 +395,16 @@ int httpd_run(httpd_t *srv)
 {
     fw_log(LOG_INFO, "firewallo-web listening on %s:%d",
            srv->bind_addr ? srv->bind_addr : "0.0.0.0", srv->port);
+
+    /* SEC-011: Warn that the server has no TLS support */
+    fw_log(LOG_WARN,
+           "WARNING: Server is running plain HTTP without TLS encryption.");
+    fw_log(LOG_WARN,
+           "All traffic is transmitted in cleartext. Do NOT expose this "
+           "server directly to untrusted networks.");
+    fw_log(LOG_WARN,
+           "For production use, place behind a TLS reverse proxy "
+           "(nginx, Caddy, HAProxy) and bind to 127.0.0.1 (-b 127.0.0.1).");
 
     /* Install SIGCHLD handler to set reap flag */
     struct sigaction sa;

--- a/src/web/main.c
+++ b/src/web/main.c
@@ -93,16 +93,6 @@ int main(int argc, char *argv[])
     signal(SIGTERM, sigint_handler);
     signal(SIGPIPE, SIG_IGN);
 
-    /* SEC-011: Warn when binding to all interfaces (no TLS available) */
-    if (strcmp(bind_addr, "0.0.0.0") == 0) {
-        fw_log(LOG_WARN,
-               "Binding to 0.0.0.0 — the server will be reachable from "
-               "all network interfaces over plaintext HTTP.");
-        fw_log(LOG_WARN,
-               "Consider using -b 127.0.0.1 and a TLS reverse proxy "
-               "for production deployments.");
-    }
-
     /* Init and run server */
     if (httpd_init(&server, bind_addr, port, webroot, config_path, &cfg) != 0) {
         fprintf(stderr, "Failed to start server on port %d\n", port);

--- a/src/web/main.c
+++ b/src/web/main.c
@@ -93,6 +93,16 @@ int main(int argc, char *argv[])
     signal(SIGTERM, sigint_handler);
     signal(SIGPIPE, SIG_IGN);
 
+    /* SEC-011: Warn when binding to all interfaces (no TLS available) */
+    if (strcmp(bind_addr, "0.0.0.0") == 0) {
+        fw_log(LOG_WARN,
+               "Binding to 0.0.0.0 — the server will be reachable from "
+               "all network interfaces over plaintext HTTP.");
+        fw_log(LOG_WARN,
+               "Consider using -b 127.0.0.1 and a TLS reverse proxy "
+               "for production deployments.");
+    }
+
     /* Init and run server */
     if (httpd_init(&server, bind_addr, port, webroot, config_path, &cfg) != 0) {
         fprintf(stderr, "Failed to start server on port %d\n", port);


### PR DESCRIPTION
## Task SEC-011 — Add TLS warning and document reverse proxy requirement

### Summary
- Added startup `LOG_WARN` messages about plaintext HTTP and TLS reverse proxy recommendation
- Added extra warning when bound to `0.0.0.0` (accessible from all interfaces)
- Documented reverse proxy requirement with example nginx config in `httpd.c`
- No TLS implementation (project policy: no external dependencies)

### Related Issue
Refs #19 (SEC-011)

---
*Generated by Claude Code via `/task-pick`*