### PR TITLE
[FW-0004] Time-based / scheduled firewall rules

### DIFF
--- a/include/firewallo/types.h
+++ b/include/firewallo/types.h
@@ -67,6 +67,16 @@ typedef struct {
     int end;
 } fw_port_t;
 
+/* Time-based schedule for rules */
+typedef struct {
+    int enabled;
+    int hour_start;
+    int minute_start;
+    int hour_end;
+    int minute_end;
+    unsigned char days; /* bitmask: bit0=Mon, bit1=Tue, ..., bit6=Sun */
+} fw_schedule_t;
+
 /* Explicit filter rule (beyond simple port opens) */
 typedef struct {
     char src_addr[FW_MAX_ADDR];
@@ -76,6 +86,7 @@ typedef struct {
     fw_port_t dst_port;
     fw_action_t action;
     char comment[FW_MAX_COMMENT];
+    fw_schedule_t schedule;
 } fw_filter_rule_t;
 
 /* A filter chain (one of 25) */

--- a/include/firewallo/util.h
+++ b/include/firewallo/util.h
@@ -2,6 +2,7 @@
 #define FIREWALLO_UTIL_H
 
 #include <stddef.h>
+#include <string.h>
 
 /* Safe string copy — always null-terminates, returns bytes written (excluding NUL) */
 size_t fw_strlcpy(char *dst, const char *src, size_t size);
@@ -17,5 +18,22 @@ int fw_strcasecmp(const char *a, const char *b);
 
 /* Check if string is empty or NULL */
 int fw_str_empty(const char *s);
+
+/*
+ * Build a comma-separated (or custom separator) string of day names from a
+ * bitmask (bit 0 = Monday … bit 6 = Sunday).
+ *
+ * names  – array of 7 day-name strings (e.g. {"Mon","Tue",…} or
+ *          {"Monday","Tuesday",…})
+ * sep    – separator between names (e.g. "," or ", ")
+ * days   – bitmask of active days
+ * buf    – output buffer
+ * len    – size of output buffer
+ *
+ * Returns the number of characters written (excluding NUL), or 0 if no days
+ * are set.
+ */
+size_t fw_schedule_days_str(unsigned char days, char *buf, size_t len,
+                            const char *names[], const char *sep);
 
 #endif /* FIREWALLO_UTIL_H */

--- a/include/firewallo/validate.h
+++ b/include/firewallo/validate.h
@@ -1,6 +1,8 @@
 #ifndef FIREWALLO_VALIDATE_H
 #define FIREWALLO_VALIDATE_H
 
+#include "firewallo/types.h"
+
 /* All validators return 1 if valid, 0 if invalid */
 
 /* Validate IPv4 address (e.g. "192.168.1.1") */
@@ -32,5 +34,8 @@ int fw_validate_addr_field(const char *addr);
 
 /* Validate mangle mark (hex string like "0x1" or decimal) */
 int fw_validate_mark(const char *mark);
+
+/* Validate a time-based schedule (hour 0-23, minute 0-59, valid day bitmask) */
+int fw_validate_schedule(const fw_schedule_t *sched);
 
 #endif /* FIREWALLO_VALIDATE_H */

--- a/src/lib/backend_ipt.c
+++ b/src/lib/backend_ipt.c
@@ -238,6 +238,29 @@ static void ipt_add_filter_explicit_rule(fw_cmdlist_t *out, const char *chain,
                             " --sport %d", rule->src_port.start);
     }
 
+    /* Schedule constraints */
+    if (rule->schedule.enabled) {
+        pos += snprintf(buf + pos, sizeof(buf) - (size_t)pos,
+                        " -m time --timestart %02d:%02d --timestop %02d:%02d",
+                        rule->schedule.hour_start, rule->schedule.minute_start,
+                        rule->schedule.hour_end, rule->schedule.minute_end);
+
+        /* Build weekdays list */
+        const char *day_abbr[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
+        char days_buf[64] = {0};
+        int first = 1;
+        for (int d = 0; d < 7; d++) {
+            if (rule->schedule.days & (1 << d)) {
+                if (!first) strncat(days_buf, ",", sizeof(days_buf) - strlen(days_buf) - 1);
+                strncat(days_buf, day_abbr[d], sizeof(days_buf) - strlen(days_buf) - 1);
+                first = 0;
+            }
+        }
+        if (days_buf[0])
+            pos += snprintf(buf + pos, sizeof(buf) - (size_t)pos,
+                            " --weekdays %s", days_buf);
+    }
+
     /* LOG then ACTION (iptables needs two separate rules) */
     const char *comment = rule->comment[0] ? rule->comment : chain;
     fw_cmdlist_append(out, "%s -j LOG --log-level info --log-prefix \"%s :\"", buf, comment);
@@ -265,6 +288,27 @@ static void ipt_add_filter_explicit_rule(fw_cmdlist_t *out, const char *chain,
         else
             pos += snprintf(buf + pos, sizeof(buf) - (size_t)pos,
                             " --sport %d", rule->src_port.start);
+    }
+    /* Re-add schedule for the action rule too */
+    if (rule->schedule.enabled) {
+        pos += snprintf(buf + pos, sizeof(buf) - (size_t)pos,
+                        " -m time --timestart %02d:%02d --timestop %02d:%02d",
+                        rule->schedule.hour_start, rule->schedule.minute_start,
+                        rule->schedule.hour_end, rule->schedule.minute_end);
+
+        const char *day_abbr2[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
+        char days_buf2[64] = {0};
+        int first2 = 1;
+        for (int d = 0; d < 7; d++) {
+            if (rule->schedule.days & (1 << d)) {
+                if (!first2) strncat(days_buf2, ",", sizeof(days_buf2) - strlen(days_buf2) - 1);
+                strncat(days_buf2, day_abbr2[d], sizeof(days_buf2) - strlen(days_buf2) - 1);
+                first2 = 0;
+            }
+        }
+        if (days_buf2[0])
+            pos += snprintf(buf + pos, sizeof(buf) - (size_t)pos,
+                            " --weekdays %s", days_buf2);
     }
     fw_cmdlist_append(out, "%s -j %s", buf, act);
 }

--- a/src/lib/backend_ipt.c
+++ b/src/lib/backend_ipt.c
@@ -1,5 +1,6 @@
 #include "firewallo/backend.h"
 #include "firewallo/rule_compiler.h"
+#include "firewallo/util.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -246,16 +247,9 @@ static void ipt_add_filter_explicit_rule(fw_cmdlist_t *out, const char *chain,
                         rule->schedule.hour_end, rule->schedule.minute_end);
 
         /* Build weekdays list */
-        const char *day_abbr[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
-        char days_buf[64] = {0};
-        int first = 1;
-        for (int d = 0; d < 7; d++) {
-            if (rule->schedule.days & (1 << d)) {
-                if (!first) strncat(days_buf, ",", sizeof(days_buf) - strlen(days_buf) - 1);
-                strncat(days_buf, day_abbr[d], sizeof(days_buf) - strlen(days_buf) - 1);
-                first = 0;
-            }
-        }
+        static const char *day_abbr[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
+        char days_buf[64];
+        fw_schedule_days_str(rule->schedule.days, days_buf, sizeof(days_buf), day_abbr, ",");
         if (days_buf[0])
             pos += snprintf(buf + pos, sizeof(buf) - (size_t)pos,
                             " --weekdays %s", days_buf);
@@ -296,16 +290,9 @@ static void ipt_add_filter_explicit_rule(fw_cmdlist_t *out, const char *chain,
                         rule->schedule.hour_start, rule->schedule.minute_start,
                         rule->schedule.hour_end, rule->schedule.minute_end);
 
-        const char *day_abbr2[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
-        char days_buf2[64] = {0};
-        int first2 = 1;
-        for (int d = 0; d < 7; d++) {
-            if (rule->schedule.days & (1 << d)) {
-                if (!first2) strncat(days_buf2, ",", sizeof(days_buf2) - strlen(days_buf2) - 1);
-                strncat(days_buf2, day_abbr2[d], sizeof(days_buf2) - strlen(days_buf2) - 1);
-                first2 = 0;
-            }
-        }
+        static const char *day_abbr2[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
+        char days_buf2[64];
+        fw_schedule_days_str(rule->schedule.days, days_buf2, sizeof(days_buf2), day_abbr2, ",");
         if (days_buf2[0])
             pos += snprintf(buf + pos, sizeof(buf) - (size_t)pos,
                             " --weekdays %s", days_buf2);

--- a/src/lib/backend_nft.c
+++ b/src/lib/backend_nft.c
@@ -1,5 +1,6 @@
 #include "firewallo/backend.h"
 #include "firewallo/rule_compiler.h"
+#include "firewallo/util.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -247,17 +248,10 @@ static void nft_add_filter_explicit_rule(fw_cmdlist_t *out, const char *chain,
                         rule->schedule.hour_end, rule->schedule.minute_end);
 
         /* Build day list for meta day */
-        const char *day_names[] = {"Monday", "Tuesday", "Wednesday", "Thursday",
-                                   "Friday", "Saturday", "Sunday"};
-        char days_buf[256] = {0};
-        int first = 1;
-        for (int d = 0; d < 7; d++) {
-            if (rule->schedule.days & (1 << d)) {
-                if (!first) strncat(days_buf, ",", sizeof(days_buf) - strlen(days_buf) - 1);
-                strncat(days_buf, day_names[d], sizeof(days_buf) - strlen(days_buf) - 1);
-                first = 0;
-            }
-        }
+        static const char *day_names[] = {"Monday", "Tuesday", "Wednesday", "Thursday",
+                                          "Friday", "Saturday", "Sunday"};
+        char days_buf[256];
+        fw_schedule_days_str(rule->schedule.days, days_buf, sizeof(days_buf), day_names, ", ");
         if (days_buf[0])
             pos += snprintf(buf + pos, sizeof(buf) - (size_t)pos,
                             " meta day { %s }", days_buf);

--- a/src/lib/backend_nft.c
+++ b/src/lib/backend_nft.c
@@ -239,6 +239,30 @@ static void nft_add_filter_explicit_rule(fw_cmdlist_t *out, const char *chain,
                             " dport %d", rule->dst_port.start);
     }
 
+    /* Schedule constraints */
+    if (rule->schedule.enabled) {
+        pos += snprintf(buf + pos, sizeof(buf) - (size_t)pos,
+                        " meta hour \\\"%02d:%02d\\\"-\\\"%02d:%02d\\\"",
+                        rule->schedule.hour_start, rule->schedule.minute_start,
+                        rule->schedule.hour_end, rule->schedule.minute_end);
+
+        /* Build day list for meta day */
+        const char *day_names[] = {"Monday", "Tuesday", "Wednesday", "Thursday",
+                                   "Friday", "Saturday", "Sunday"};
+        char days_buf[256] = {0};
+        int first = 1;
+        for (int d = 0; d < 7; d++) {
+            if (rule->schedule.days & (1 << d)) {
+                if (!first) strncat(days_buf, ",", sizeof(days_buf) - strlen(days_buf) - 1);
+                strncat(days_buf, day_names[d], sizeof(days_buf) - strlen(days_buf) - 1);
+                first = 0;
+            }
+        }
+        if (days_buf[0])
+            pos += snprintf(buf + pos, sizeof(buf) - (size_t)pos,
+                            " meta day { %s }", days_buf);
+    }
+
     const char *comment = rule->comment[0] ? rule->comment : chain;
     snprintf(buf + pos, sizeof(buf) - (size_t)pos,
              " log prefix \\\"%s : \\\" counter %s", comment, act);

--- a/src/lib/config.c
+++ b/src/lib/config.c
@@ -613,16 +613,9 @@ static json_value_t *build_filter_rules(const fw_filter_rule_t *rules, int count
             json_object_set(sched, "end", json_new_string(time_buf));
 
             /* Build day names string */
-            const char *day_names[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
-            char days_str[64] = {0};
-            int first = 1;
-            for (int d = 0; d < 7; d++) {
-                if (r->schedule.days & (1 << d)) {
-                    if (!first) strncat(days_str, ",", sizeof(days_str) - strlen(days_str) - 1);
-                    strncat(days_str, day_names[d], sizeof(days_str) - strlen(days_str) - 1);
-                    first = 0;
-                }
-            }
+            static const char *day_names[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
+            char days_str[64];
+            fw_schedule_days_str(r->schedule.days, days_str, sizeof(days_str), day_names, ",");
             json_object_set(sched, "days", json_new_string(days_str));
             json_object_set(obj, "schedule", sched);
         }

--- a/src/lib/config.c
+++ b/src/lib/config.c
@@ -170,6 +170,55 @@ static void load_filter_rules(const json_value_t *arr, fw_filter_rule_t out[], i
         s = json_string_value(json_object_get(rule, "comment"));
         if (s) fw_strlcpy(r->comment, s, sizeof(r->comment));
 
+        /* Parse schedule if present */
+        json_value_t *sched = json_object_get(rule, "schedule");
+        if (sched && sched->type == JSON_OBJECT) {
+            json_value_t *en = json_object_get(sched, "enabled");
+            if (en) r->schedule.enabled = json_bool_value(en);
+
+            /* Parse start time "HH:MM" */
+            s = json_string_value(json_object_get(sched, "start"));
+            if (s) {
+                int hh = 0, mm = 0;
+                if (sscanf(s, "%d:%d", &hh, &mm) == 2) {
+                    r->schedule.hour_start = hh;
+                    r->schedule.minute_start = mm;
+                }
+            }
+
+            /* Parse end time "HH:MM" */
+            s = json_string_value(json_object_get(sched, "end"));
+            if (s) {
+                int hh = 0, mm = 0;
+                if (sscanf(s, "%d:%d", &hh, &mm) == 2) {
+                    r->schedule.hour_end = hh;
+                    r->schedule.minute_end = mm;
+                }
+            }
+
+            /* Parse days as comma-separated names */
+            s = json_string_value(json_object_get(sched, "days"));
+            if (s) {
+                r->schedule.days = 0;
+                const char *day_names[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
+                /* Work on a copy to tokenize */
+                char days_buf[128];
+                fw_strlcpy(days_buf, s, sizeof(days_buf));
+                char *tok = strtok(days_buf, ",");
+                while (tok) {
+                    /* Trim leading spaces */
+                    while (*tok == ' ') tok++;
+                    for (int d = 0; d < 7; d++) {
+                        if (strncmp(tok, day_names[d], 3) == 0) {
+                            r->schedule.days |= (unsigned char)(1 << d);
+                            break;
+                        }
+                    }
+                    tok = strtok(NULL, ",");
+                }
+            }
+        }
+
         (*count)++;
     }
 }
@@ -548,6 +597,36 @@ static json_value_t *build_filter_rules(const fw_filter_rule_t *rules, int count
         json_object_set(obj, "dst_port", build_port_field(r->dst_port));
         json_object_set(obj, "action", json_new_string(action_to_string(r->action)));
         json_object_set(obj, "comment", json_new_string(r->comment));
+
+        /* Serialize schedule if enabled */
+        if (r->schedule.enabled) {
+            json_value_t *sched = json_new_object();
+            json_object_set(sched, "enabled", json_new_bool(1));
+
+            char time_buf[8];
+            snprintf(time_buf, sizeof(time_buf), "%02d:%02d",
+                     r->schedule.hour_start, r->schedule.minute_start);
+            json_object_set(sched, "start", json_new_string(time_buf));
+
+            snprintf(time_buf, sizeof(time_buf), "%02d:%02d",
+                     r->schedule.hour_end, r->schedule.minute_end);
+            json_object_set(sched, "end", json_new_string(time_buf));
+
+            /* Build day names string */
+            const char *day_names[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
+            char days_str[64] = {0};
+            int first = 1;
+            for (int d = 0; d < 7; d++) {
+                if (r->schedule.days & (1 << d)) {
+                    if (!first) strncat(days_str, ",", sizeof(days_str) - strlen(days_str) - 1);
+                    strncat(days_str, day_names[d], sizeof(days_str) - strlen(days_str) - 1);
+                    first = 0;
+                }
+            }
+            json_object_set(sched, "days", json_new_string(days_str));
+            json_object_set(obj, "schedule", sched);
+        }
+
         json_array_append(arr, obj);
     }
     return arr;
@@ -891,7 +970,7 @@ int fw_config_validate(const fw_config_t *cfg, char *err, size_t errlen)
                 return -1;
             }
         }
-        /* Validate explicit filter rules (addresses, comments) */
+        /* Validate explicit filter rules (addresses, comments, schedules) */
         for (int i = 0; i < ch->rule_count; i++) {
             const fw_filter_rule_t *r = &ch->rules[i];
             if (!fw_validate_addr_field(r->src_addr)) {
@@ -907,6 +986,12 @@ int fw_config_validate(const fw_config_t *cfg, char *err, size_t errlen)
             if (!fw_validate_comment(r->comment)) {
                 snprintf(err, errlen, "invalid comment in chain %s rule %d",
                          ch->name, i);
+                return -1;
+            }
+            if (r->schedule.enabled &&
+                !fw_validate_schedule(&r->schedule)) {
+                snprintf(err, errlen, "invalid schedule on rule %d in chain %s",
+                         i, ch->name);
                 return -1;
             }
         }

--- a/src/lib/util.c
+++ b/src/lib/util.c
@@ -123,3 +123,34 @@ int fw_str_empty(const char *s)
 {
     return s == NULL || s[0] == '\0';
 }
+
+size_t fw_schedule_days_str(unsigned char days, char *buf, size_t len,
+                            const char *names[], const char *sep)
+{
+    if (len == 0) return 0;
+    buf[0] = '\0';
+
+    size_t pos = 0;
+    size_t sep_len = strlen(sep);
+    int first = 1;
+
+    for (int d = 0; d < 7; d++) {
+        if (!(days & (1 << d))) continue;
+
+        size_t name_len = strlen(names[d]);
+
+        if (!first) {
+            if (pos + sep_len >= len) break;
+            memcpy(buf + pos, sep, sep_len);
+            pos += sep_len;
+        }
+
+        if (pos + name_len >= len) break;
+        memcpy(buf + pos, names[d], name_len);
+        pos += name_len;
+        first = 0;
+    }
+
+    buf[pos] = '\0';
+    return pos;
+}

--- a/src/lib/validate.c
+++ b/src/lib/validate.c
@@ -207,3 +207,33 @@ int fw_validate_mark(const char *mark)
     }
     return 1;
 }
+
+int fw_validate_schedule(const fw_schedule_t *sched)
+{
+    if (!sched)
+        return 0;
+
+    /* If not enabled, schedule is valid (unused) */
+    if (!sched->enabled)
+        return 1;
+
+    /* Validate hours 0-23 */
+    if (sched->hour_start < 0 || sched->hour_start > 23)
+        return 0;
+    if (sched->hour_end < 0 || sched->hour_end > 23)
+        return 0;
+
+    /* Validate minutes 0-59 */
+    if (sched->minute_start < 0 || sched->minute_start > 59)
+        return 0;
+    if (sched->minute_end < 0 || sched->minute_end > 59)
+        return 0;
+
+    /* Days bitmask must have at least one day set (bits 0-6) */
+    if (sched->days == 0)
+        return 0;
+    if (sched->days & ~0x7F)
+        return 0;
+
+    return 1;
+}

--- a/src/web/api.c
+++ b/src/web/api.c
@@ -293,6 +293,33 @@ static void api_get_filter_chain(httpd_t *srv, const char *chain_name, http_resp
         json_object_set(obj, "action", json_new_string(
             r->action == ACTION_DROP ? "drop" : r->action == ACTION_REJECT ? "reject" : "accept"));
         json_object_set(obj, "comment", json_new_string(r->comment));
+
+        /* Include schedule if enabled */
+        if (r->schedule.enabled) {
+            json_value_t *sched = json_new_object();
+            json_object_set(sched, "enabled", json_new_bool(1));
+            char tbuf[8];
+            snprintf(tbuf, sizeof(tbuf), "%02d:%02d",
+                     r->schedule.hour_start, r->schedule.minute_start);
+            json_object_set(sched, "start", json_new_string(tbuf));
+            snprintf(tbuf, sizeof(tbuf), "%02d:%02d",
+                     r->schedule.hour_end, r->schedule.minute_end);
+            json_object_set(sched, "end", json_new_string(tbuf));
+
+            const char *day_names[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
+            char days_str[64] = {0};
+            int first = 1;
+            for (int d = 0; d < 7; d++) {
+                if (r->schedule.days & (1 << d)) {
+                    if (!first) strncat(days_str, ",", sizeof(days_str) - strlen(days_str) - 1);
+                    strncat(days_str, day_names[d], sizeof(days_str) - strlen(days_str) - 1);
+                    first = 0;
+                }
+            }
+            json_object_set(sched, "days", json_new_string(days_str));
+            json_object_set(obj, "schedule", sched);
+        }
+
         json_array_append(rules, obj);
     }
     json_object_set(data, "rules", rules);

--- a/src/web/api.c
+++ b/src/web/api.c
@@ -306,16 +306,9 @@ static void api_get_filter_chain(httpd_t *srv, const char *chain_name, http_resp
                      r->schedule.hour_end, r->schedule.minute_end);
             json_object_set(sched, "end", json_new_string(tbuf));
 
-            const char *day_names[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
-            char days_str[64] = {0};
-            int first = 1;
-            for (int d = 0; d < 7; d++) {
-                if (r->schedule.days & (1 << d)) {
-                    if (!first) strncat(days_str, ",", sizeof(days_str) - strlen(days_str) - 1);
-                    strncat(days_str, day_names[d], sizeof(days_str) - strlen(days_str) - 1);
-                    first = 0;
-                }
-            }
+            static const char *day_names[] = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
+            char days_str[64];
+            fw_schedule_days_str(r->schedule.days, days_str, sizeof(days_str), day_names, ",");
             json_object_set(sched, "days", json_new_string(days_str));
             json_object_set(obj, "schedule", sched);
         }

--- a/tests/test_validate.c
+++ b/tests/test_validate.c
@@ -1,5 +1,6 @@
 #include "firewallo/validate.h"
 #include <stdio.h>
+#include <string.h>
 
 static int tests_run = 0;
 static int tests_passed = 0;
@@ -181,6 +182,84 @@ static void test_mark(void)
     ASSERT(fw_validate_mark("12abc") == 0, "mixed decimal/letters");
 }
 
+static void test_schedule(void)
+{
+    printf("test_schedule\n");
+
+    /* Valid schedules */
+    fw_schedule_t sched;
+    memset(&sched, 0, sizeof(sched));
+
+    /* Disabled schedule is always valid */
+    sched.enabled = 0;
+    ASSERT(fw_validate_schedule(&sched) == 1, "disabled schedule is valid");
+
+    /* Valid enabled schedule: Mon-Fri 08:00-17:00 */
+    sched.enabled = 1;
+    sched.hour_start = 8;
+    sched.minute_start = 0;
+    sched.hour_end = 17;
+    sched.minute_end = 0;
+    sched.days = 0x1F; /* Mon-Fri = bits 0-4 */
+    ASSERT(fw_validate_schedule(&sched) == 1, "valid weekday schedule");
+
+    /* Valid: all days, midnight to midnight */
+    sched.hour_start = 0;
+    sched.minute_start = 0;
+    sched.hour_end = 23;
+    sched.minute_end = 59;
+    sched.days = 0x7F; /* all days */
+    ASSERT(fw_validate_schedule(&sched) == 1, "valid full schedule");
+
+    /* Valid: single day */
+    sched.days = 0x01; /* Monday only */
+    ASSERT(fw_validate_schedule(&sched) == 1, "valid single day");
+
+    /* Valid: Sunday only */
+    sched.days = 0x40; /* bit 6 = Sunday */
+    ASSERT(fw_validate_schedule(&sched) == 1, "valid Sunday only");
+
+    /* Invalid: NULL */
+    ASSERT(fw_validate_schedule(NULL) == 0, "null schedule");
+
+    /* Invalid: hour out of range */
+    sched.hour_start = 24;
+    sched.days = 0x1F;
+    ASSERT(fw_validate_schedule(&sched) == 0, "hour_start 24");
+    sched.hour_start = 8;
+
+    sched.hour_end = 25;
+    ASSERT(fw_validate_schedule(&sched) == 0, "hour_end 25");
+    sched.hour_end = 17;
+
+    /* Invalid: negative hour */
+    sched.hour_start = -1;
+    ASSERT(fw_validate_schedule(&sched) == 0, "negative hour_start");
+    sched.hour_start = 8;
+
+    /* Invalid: minute out of range */
+    sched.minute_start = 60;
+    ASSERT(fw_validate_schedule(&sched) == 0, "minute_start 60");
+    sched.minute_start = 0;
+
+    sched.minute_end = 99;
+    ASSERT(fw_validate_schedule(&sched) == 0, "minute_end 99");
+    sched.minute_end = 0;
+
+    /* Invalid: negative minute */
+    sched.minute_end = -1;
+    ASSERT(fw_validate_schedule(&sched) == 0, "negative minute_end");
+    sched.minute_end = 0;
+
+    /* Invalid: no days set */
+    sched.days = 0;
+    ASSERT(fw_validate_schedule(&sched) == 0, "no days set");
+
+    /* Invalid: bits outside 0-6 */
+    sched.days = 0x80;
+    ASSERT(fw_validate_schedule(&sched) == 0, "invalid day bit 7");
+}
+
 int main(void)
 {
     printf("=== Validator Tests ===\n\n");
@@ -195,6 +274,7 @@ int main(void)
     test_comment();
     test_addr_field();
     test_mark();
+    test_schedule();
 
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return tests_passed == tests_run ? 0 : 1;


### PR DESCRIPTION
## Task FW-0004 — Time-based / scheduled firewall rules

### Summary
- Added `fw_schedule_t` struct with day bitmask and hour/minute ranges
- Implemented schedule parsing/serialization in config load/save
- Added schedule validation and test cases
- Generated `meta hour`/`meta day` for nftables and `-m time` for iptables

### Related Issue
Refs #42 (FW-0004)

---
*Generated by Claude Code via `/task-pick`*