### PR TITLE
[FW-0001] Automatic rollback timer for safe rule application

### DIFF
--- a/include/firewallo/rollback.h
+++ b/include/firewallo/rollback.h
@@ -10,11 +10,16 @@
 /* Default rollback timeout in seconds */
 #define FW_ROLLBACK_DEFAULT_TIMEOUT 60
 
+/* State file path for cross-process rollback communication */
+#define FW_ROLLBACK_STATE_DIR  "/run/firewallo"
+#define FW_ROLLBACK_STATE_FILE "/run/firewallo/rollback.state"
+
 /* Rollback state */
 typedef struct {
     int pending;                                /* 1 if a rollback is pending */
     time_t deadline;                            /* UNIX timestamp when rollback triggers */
     char backup_path[FW_ROLLBACK_BACKUP_PATH_MAX]; /* Path to backup config file */
+    char config_path[FW_ROLLBACK_BACKUP_PATH_MAX]; /* Original config file path */
 } fw_rollback_state_t;
 
 /* Create a backup of the current config at the given path.
@@ -37,11 +42,32 @@ int fw_rollback_confirm(void);
    Returns 0 on success, -1 if no rollback is pending. */
 int fw_rollback_cancel(void);
 
+/* Perform an immediate rollback using the saved backup.
+   Stops current rules, loads backup config, and reapplies.
+   Returns 0 on success, -1 on error. */
+int fw_rollback_perform(void);
+
 /* Query the current rollback state. Returns 0 on success. */
 int fw_rollback_status(fw_rollback_state_t *state);
 
-/* Set the config pointer and config path used by the signal handler
-   for automatic rollback. Must be called before fw_rollback_start(). */
+/* Set the config pointer and config path used for rollback.
+   Must be called before fw_rollback_start(). */
 void fw_rollback_set_context(fw_config_t *cfg, const char *config_path);
+
+/* Check the volatile flag set by SIGALRM and perform rollback if needed.
+   Call this from a main loop or poll loop. Returns 1 if rollback was
+   triggered, 0 otherwise. */
+int fw_rollback_check(void);
+
+/* Write rollback state to the state file for cross-process communication.
+   Returns 0 on success. */
+int fw_rollback_state_save(const fw_rollback_state_t *state);
+
+/* Read rollback state from the state file.
+   Returns 0 on success, -1 if no state file or error. */
+int fw_rollback_state_load(fw_rollback_state_t *state);
+
+/* Remove the state file. */
+void fw_rollback_state_remove(void);
 
 #endif /* FIREWALLO_ROLLBACK_H */

--- a/include/firewallo/rollback.h
+++ b/include/firewallo/rollback.h
@@ -1,0 +1,47 @@
+#ifndef FIREWALLO_ROLLBACK_H
+#define FIREWALLO_ROLLBACK_H
+
+#include "firewallo/types.h"
+#include <time.h>
+
+/* Maximum path length for backup file */
+#define FW_ROLLBACK_BACKUP_PATH_MAX 256
+
+/* Default rollback timeout in seconds */
+#define FW_ROLLBACK_DEFAULT_TIMEOUT 60
+
+/* Rollback state */
+typedef struct {
+    int pending;                                /* 1 if a rollback is pending */
+    time_t deadline;                            /* UNIX timestamp when rollback triggers */
+    char backup_path[FW_ROLLBACK_BACKUP_PATH_MAX]; /* Path to backup config file */
+} fw_rollback_state_t;
+
+/* Create a backup of the current config at the given path.
+   Returns 0 on success, -1 on error. */
+int fw_config_backup(const fw_config_t *cfg, const char *backup_path);
+
+/* Restore config from a backup file and reload it into cfg.
+   Returns 0 on success, -1 on error. */
+int fw_config_rollback(const char *backup_path, fw_config_t *cfg);
+
+/* Start the rollback timer. After timeout_seconds, if not confirmed,
+   the config will be automatically rolled back. Returns 0 on success. */
+int fw_rollback_start(int timeout_seconds);
+
+/* Confirm the current configuration, cancelling any pending rollback.
+   Returns 0 on success, -1 if no rollback is pending. */
+int fw_rollback_confirm(void);
+
+/* Cancel the pending rollback timer without confirming (e.g. on error).
+   Returns 0 on success, -1 if no rollback is pending. */
+int fw_rollback_cancel(void);
+
+/* Query the current rollback state. Returns 0 on success. */
+int fw_rollback_status(fw_rollback_state_t *state);
+
+/* Set the config pointer and config path used by the signal handler
+   for automatic rollback. Must be called before fw_rollback_start(). */
+void fw_rollback_set_context(fw_config_t *cfg, const char *config_path);
+
+#endif /* FIREWALLO_ROLLBACK_H */

--- a/src/cli/commands.c
+++ b/src/cli/commands.c
@@ -2,6 +2,7 @@
 #include "firewallo/config.h"
 #include "firewallo/rule_compiler.h"
 #include "firewallo/sysctl.h"
+#include "firewallo/rollback.h"
 #include "firewallo/log.h"
 #include "firewallo/i18n.h"
 #include "firewallo/json.h"
@@ -947,6 +948,75 @@ int cmd_reload(fw_config_t *cfg, const char *config_path, int verbose)
     }
 
     return cmd_start(cfg, verbose);
+}
+
+/* ── Confirm (rollback) ────────────────────────────────────────────── */
+
+int cmd_confirm(void)
+{
+    if (fw_rollback_confirm() != 0) {
+        fprintf(stderr, "No pending rollback to confirm\n");
+        return 1;
+    }
+    printf("Configuration confirmed, rollback timer cancelled\n");
+    return 0;
+}
+
+/* ── Start with rollback ──────────────────────────────────────────── */
+
+int cmd_start_with_rollback(fw_config_t *cfg, const char *config_path,
+                            int verbose, int rollback_timeout)
+{
+    /* Set rollback context */
+    fw_rollback_set_context(cfg, config_path);
+
+    /* Start rollback timer before applying */
+    if (fw_rollback_start(rollback_timeout) != 0) {
+        fprintf(stderr, "Failed to start rollback timer\n");
+        return 1;
+    }
+
+    printf("Rollback timer started: %d seconds to confirm\n", rollback_timeout);
+
+    /* Apply rules */
+    int ret = cmd_start(cfg, verbose);
+    if (ret != 0) {
+        /* Apply failed, cancel the timer and rollback immediately */
+        fw_rollback_cancel();
+        return ret;
+    }
+
+    printf("Run 'firewallo confirm' within %d seconds to keep this configuration\n",
+           rollback_timeout);
+    return 0;
+}
+
+/* ── Reload with rollback ─────────────────────────────────────────── */
+
+int cmd_reload_with_rollback(fw_config_t *cfg, const char *config_path,
+                             int verbose, int rollback_timeout)
+{
+    /* Set rollback context */
+    fw_rollback_set_context(cfg, config_path);
+
+    /* Start rollback timer before applying */
+    if (fw_rollback_start(rollback_timeout) != 0) {
+        fprintf(stderr, "Failed to start rollback timer\n");
+        return 1;
+    }
+
+    printf("Rollback timer started: %d seconds to confirm\n", rollback_timeout);
+
+    /* Reload rules */
+    int ret = cmd_reload(cfg, config_path, verbose);
+    if (ret != 0) {
+        fw_rollback_cancel();
+        return ret;
+    }
+
+    printf("Run 'firewallo confirm' within %d seconds to keep this configuration\n",
+           rollback_timeout);
+    return 0;
 }
 
 /* ── Version ───────────────────────────────────────────────────────── */

--- a/src/cli/commands.c
+++ b/src/cli/commands.c
@@ -13,6 +13,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h>
+#include <signal.h>
 
 /* ── Helpers ───────────────────────────────────────────────────────── */
 
@@ -954,12 +956,50 @@ int cmd_reload(fw_config_t *cfg, const char *config_path, int verbose)
 
 int cmd_confirm(void)
 {
+    /* Uses state file for cross-process communication (comment 3).
+       fw_rollback_confirm() checks both in-process state and the
+       state file written by the process that started the rollback. */
     if (fw_rollback_confirm() != 0) {
         fprintf(stderr, "No pending rollback to confirm\n");
         return 1;
     }
     printf("Configuration confirmed, rollback timer cancelled\n");
     return 0;
+}
+
+/* ── Wait for confirm or timeout (comment 10) ─────────────────────── */
+
+/* Helper: wait in a loop for confirmation (via state file removal)
+   or SIGALRM timeout. The CLI must stay running for the alarm to fire. */
+static int wait_for_confirm_or_timeout(int rollback_timeout)
+{
+    printf("Run 'firewallo confirm' within %d seconds to keep this configuration\n",
+           rollback_timeout);
+    printf("Waiting for confirmation...\n");
+
+    /* Poll loop: check if state file was removed (confirm from another process)
+       or if SIGALRM fired (timeout). sleep(1) is interrupted by SIGALRM. */
+    while (1) {
+        /* Check if SIGALRM fired */
+        if (fw_rollback_check()) {
+            printf("Timeout reached, configuration rolled back automatically\n");
+            return 1;
+        }
+
+        /* Check if state file was removed by 'firewallo confirm' */
+        fw_rollback_state_t state;
+        if (fw_rollback_state_load(&state) != 0 || !state.pending) {
+            /* State file gone or no longer pending: confirmed by another process */
+            alarm(0); /* cancel our alarm */
+            printf("Configuration confirmed (by another process)\n");
+
+            /* Clean up in-process state */
+            fw_rollback_cancel();
+            return 0;
+        }
+
+        sleep(1);
+    }
 }
 
 /* ── Start with rollback ──────────────────────────────────────────── */
@@ -981,14 +1021,14 @@ int cmd_start_with_rollback(fw_config_t *cfg, const char *config_path,
     /* Apply rules */
     int ret = cmd_start(cfg, verbose);
     if (ret != 0) {
-        /* Apply failed, cancel the timer and rollback immediately */
-        fw_rollback_cancel();
+        /* Apply failed: perform immediate rollback using saved backup (comment 7) */
+        fprintf(stderr, "Apply failed, performing immediate rollback...\n");
+        fw_rollback_perform();
         return ret;
     }
 
-    printf("Run 'firewallo confirm' within %d seconds to keep this configuration\n",
-           rollback_timeout);
-    return 0;
+    /* Keep CLI running until confirm or timeout (comment 10) */
+    return wait_for_confirm_or_timeout(rollback_timeout);
 }
 
 /* ── Reload with rollback ─────────────────────────────────────────── */
@@ -1010,13 +1050,14 @@ int cmd_reload_with_rollback(fw_config_t *cfg, const char *config_path,
     /* Reload rules */
     int ret = cmd_reload(cfg, config_path, verbose);
     if (ret != 0) {
-        fw_rollback_cancel();
+        /* Reload failed: perform immediate rollback using saved backup (comment 7) */
+        fprintf(stderr, "Reload failed, performing immediate rollback...\n");
+        fw_rollback_perform();
         return ret;
     }
 
-    printf("Run 'firewallo confirm' within %d seconds to keep this configuration\n",
-           rollback_timeout);
-    return 0;
+    /* Keep CLI running until confirm or timeout (comment 10) */
+    return wait_for_confirm_or_timeout(rollback_timeout);
 }
 
 /* ── Version ───────────────────────────────────────────────────────── */

--- a/src/cli/commands.h
+++ b/src/cli/commands.h
@@ -35,4 +35,11 @@ int cmd_set_ratelimit(fw_config_t *cfg, const char *chain, const char *max_str,
                       const char *period_str, const char *ban_str,
                       const char *config_path);
 
+/* Rollback commands (FW-0001) */
+int cmd_confirm(void);
+int cmd_start_with_rollback(fw_config_t *cfg, const char *config_path,
+                            int verbose, int rollback_timeout);
+int cmd_reload_with_rollback(fw_config_t *cfg, const char *config_path,
+                             int verbose, int rollback_timeout);
+
 #endif /* FIREWALLO_CLI_COMMANDS_H */

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -1,9 +1,11 @@
 #include "commands.h"
 #include "firewallo/config.h"
 #include "firewallo/rule_compiler.h"
+#include "firewallo/rollback.h"
 #include "firewallo/log.h"
 #include "firewallo/i18n.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <getopt.h>
@@ -27,6 +29,7 @@ static void print_usage(void)
         "  export          Export configuration backup\n"
         "  restore <file>  Restore configuration from backup\n"
         "  switch <nft|ipt> Switch backend between nftables and iptables\n"
+        "  confirm         Confirm pending config (cancel rollback timer)\n"
         "  version         Show version\n"
         "\n"
         "Config editing:\n"
@@ -42,6 +45,7 @@ static void print_usage(void)
         "  -c, --config <path>  Config file (default: /etc/firewallo/firewallo.json)\n"
         "  -v, --verbose        Verbose output (show all commands)\n"
         "  -n, --dry-run        Show commands without executing\n"
+        "  -t, --rollback-timeout <N>  Auto-rollback after N seconds (default: 60)\n"
         "  -h, --help           Show this help\n"
     );
 }
@@ -51,17 +55,19 @@ int main(int argc, char *argv[])
     const char *config_path = FW_DEFAULT_CONFIG_PATH;
     int verbose = 0;
     int dry_run = 0;
+    int rollback_timeout = 0; /* 0 means no rollback timer */
 
     static struct option long_opts[] = {
-        {"config",  required_argument, NULL, 'c'},
-        {"verbose", no_argument,       NULL, 'v'},
-        {"dry-run", no_argument,       NULL, 'n'},
-        {"help",    no_argument,       NULL, 'h'},
+        {"config",           required_argument, NULL, 'c'},
+        {"verbose",          no_argument,       NULL, 'v'},
+        {"dry-run",          no_argument,       NULL, 'n'},
+        {"rollback-timeout", required_argument, NULL, 't'},
+        {"help",             no_argument,       NULL, 'h'},
         {NULL, 0, NULL, 0}
     };
 
     int opt;
-    while ((opt = getopt_long(argc, argv, "c:vnh", long_opts, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "c:vnt:h", long_opts, NULL)) != -1) {
         switch (opt) {
         case 'c':
             config_path = optarg;
@@ -72,6 +78,13 @@ int main(int argc, char *argv[])
         case 'n':
             dry_run = 1;
             verbose = 1;
+            break;
+        case 't':
+            rollback_timeout = atoi(optarg);
+            if (rollback_timeout <= 0) {
+                fprintf(stderr, "Rollback timeout must be a positive integer\n");
+                return 1;
+            }
             break;
         case 'h':
             print_usage();
@@ -132,9 +145,12 @@ int main(int argc, char *argv[])
 
     /* Dispatch command */
     int ret = 0;
-    if (strcmp(command, "start") == 0)
-        ret = cmd_start(&cfg, verbose);
-    else if (strcmp(command, "stop") == 0)
+    if (strcmp(command, "start") == 0) {
+        if (rollback_timeout > 0)
+            ret = cmd_start_with_rollback(&cfg, config_path, verbose, rollback_timeout);
+        else
+            ret = cmd_start(&cfg, verbose);
+    } else if (strcmp(command, "stop") == 0)
         ret = cmd_stop(&cfg, verbose);
     else if (strcmp(command, "restart") == 0)
         ret = cmd_restart(&cfg, config_path, verbose);
@@ -164,8 +180,13 @@ int main(int argc, char *argv[])
             return 1;
         }
         ret = cmd_switch_backend(&cfg, argv[optind + 1], config_path);
-    } else if (strcmp(command, "reload") == 0)
-        ret = cmd_reload(&cfg, config_path, verbose);
+    } else if (strcmp(command, "reload") == 0) {
+        if (rollback_timeout > 0)
+            ret = cmd_reload_with_rollback(&cfg, config_path, verbose, rollback_timeout);
+        else
+            ret = cmd_reload(&cfg, config_path, verbose);
+    } else if (strcmp(command, "confirm") == 0)
+        ret = cmd_confirm();
     else if (strcmp(command, "set-interface") == 0) {
         if (optind + 3 >= argc) {
             fprintf(stderr, "Usage: firewallo set-interface <zone> <add|remove> <iface>\n");

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -45,7 +45,7 @@ static void print_usage(void)
         "  -c, --config <path>  Config file (default: /etc/firewallo/firewallo.json)\n"
         "  -v, --verbose        Verbose output (show all commands)\n"
         "  -n, --dry-run        Show commands without executing\n"
-        "  -t, --rollback-timeout <N>  Auto-rollback after N seconds (default: 60)\n"
+        "  -t, --rollback-timeout <N>  Auto-rollback after N seconds (opt-in, disabled by default)\n"
         "  -h, --help           Show this help\n"
     );
 }

--- a/src/lib/rollback.c
+++ b/src/lib/rollback.c
@@ -7,7 +7,12 @@
 #include <signal.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+
 
 /* ── Static rollback state ────────────────────────────────────────── */
 
@@ -15,53 +20,98 @@ static fw_rollback_state_t rollback_state;
 static fw_config_t *rollback_cfg_ptr;
 static char rollback_config_path[FW_ROLLBACK_BACKUP_PATH_MAX];
 
+/* Atomic flag for async-signal-safe SIGALRM handler (comment 9) */
+static volatile sig_atomic_t rollback_alarm_fired = 0;
+
 /* ── Signal handler for SIGALRM ───────────────────────────────────── */
 
+/* Only sets an atomic flag. All real work is done in fw_rollback_check()
+   which must be called from the main loop. (comment 9) */
 static void sigalrm_handler(int sig)
 {
     (void)sig;
+    rollback_alarm_fired = 1;
+}
 
-    if (!rollback_state.pending)
-        return;
+/* ── State file I/O for cross-process communication (comment 3) ──── */
 
-    /* Perform rollback: load backup and reapply rules */
-    if (rollback_cfg_ptr && rollback_state.backup_path[0]) {
-        fw_config_t backup_cfg;
-        char err[256] = {0};
+/* Fallback state file path when /run/firewallo is not writable */
+#define FW_ROLLBACK_STATE_FILE_FALLBACK "/tmp/.firewallo_rollback.state"
 
-        if (fw_config_load(rollback_state.backup_path, &backup_cfg, err, sizeof(err)) == 0) {
-            /* Stop current rules */
-            fw_cmdlist_t stop_cmds;
-            fw_compile_stop(&backup_cfg, &stop_cmds);
-            int fail_idx;
-            fw_cmdlist_exec(&stop_cmds, &fail_idx);
-            fw_cmdlist_free(&stop_cmds);
-
-            /* Apply sysctl from backup */
-            fw_sysctl_apply(&backup_cfg);
-
-            /* Recompile and apply backup rules */
-            fw_cmdlist_t start_cmds;
-            fw_compile_start(&backup_cfg, &start_cmds);
-            fw_cmdlist_exec(&start_cmds, &fail_idx);
-            fw_cmdlist_free(&start_cmds);
-
-            /* Restore the config struct */
-            *rollback_cfg_ptr = backup_cfg;
-
-            /* Save the restored config to disk */
-            if (rollback_config_path[0])
-                fw_config_save(rollback_config_path, &backup_cfg);
-        }
-
-        /* Clean up backup file */
-        unlink(rollback_state.backup_path);
+/* Determine the usable state file path. Try primary, fall back to /tmp. */
+static const char *get_state_file_path(void)
+{
+    /* Try creating /run/firewallo */
+    if (mkdir(FW_ROLLBACK_STATE_DIR, 0755) == 0 || errno == EEXIST) {
+        /* Check if we can write there */
+        if (access(FW_ROLLBACK_STATE_DIR, W_OK) == 0)
+            return FW_ROLLBACK_STATE_FILE;
     }
+    return FW_ROLLBACK_STATE_FILE_FALLBACK;
+}
 
-    /* Reset state */
-    rollback_state.pending = 0;
-    rollback_state.deadline = 0;
-    memset(rollback_state.backup_path, 0, sizeof(rollback_state.backup_path));
+/* Check both possible locations for the state file */
+static const char *find_state_file(void)
+{
+    if (access(FW_ROLLBACK_STATE_FILE, R_OK) == 0)
+        return FW_ROLLBACK_STATE_FILE;
+    if (access(FW_ROLLBACK_STATE_FILE_FALLBACK, R_OK) == 0)
+        return FW_ROLLBACK_STATE_FILE_FALLBACK;
+    return NULL;
+}
+
+int fw_rollback_state_save(const fw_rollback_state_t *state)
+{
+    const char *path = get_state_file_path();
+
+    FILE *f = fopen(path, "w");
+    if (!f)
+        return -1;
+
+    fprintf(f, "pending=%d\n", state->pending);
+    fprintf(f, "deadline=%ld\n", (long)state->deadline);
+    fprintf(f, "backup_path=%s\n", state->backup_path);
+    fprintf(f, "config_path=%s\n", state->config_path);
+    fclose(f);
+    return 0;
+}
+
+int fw_rollback_state_load(fw_rollback_state_t *state)
+{
+    const char *path = find_state_file();
+    if (!path)
+        return -1;
+
+    FILE *f = fopen(path, "r");
+    if (!f)
+        return -1;
+
+    memset(state, 0, sizeof(*state));
+
+    char line[512];
+    while (fgets(line, sizeof(line), f)) {
+        /* Strip newline */
+        size_t len = strlen(line);
+        if (len > 0 && line[len - 1] == '\n')
+            line[len - 1] = '\0';
+
+        if (strncmp(line, "pending=", 8) == 0)
+            state->pending = atoi(line + 8);
+        else if (strncmp(line, "deadline=", 9) == 0)
+            state->deadline = (time_t)atol(line + 9);
+        else if (strncmp(line, "backup_path=", 12) == 0)
+            fw_strlcpy(state->backup_path, line + 12, sizeof(state->backup_path));
+        else if (strncmp(line, "config_path=", 12) == 0)
+            fw_strlcpy(state->config_path, line + 12, sizeof(state->config_path));
+    }
+    fclose(f);
+    return 0;
+}
+
+void fw_rollback_state_remove(void)
+{
+    unlink(FW_ROLLBACK_STATE_FILE);
+    unlink(FW_ROLLBACK_STATE_FILE_FALLBACK);
 }
 
 /* ── Public API ───────────────────────────────────────────────────── */
@@ -98,19 +148,62 @@ int fw_rollback_start(int timeout_seconds)
         return -1;
     }
 
-    /* Generate backup path */
-    snprintf(rollback_state.backup_path, sizeof(rollback_state.backup_path),
-             "/tmp/.firewallo_rollback_%d.json", (int)getpid());
+    /* Handle already-pending rollback: clean up previous state (comment 4) */
+    if (rollback_state.pending) {
+        fw_log(LOG_WARN, "rollback: cleaning up previous pending rollback");
+        alarm(0); /* cancel previous alarm */
+        if (rollback_state.backup_path[0])
+            unlink(rollback_state.backup_path);
+        rollback_state.pending = 0;
+        rollback_state.deadline = 0;
+        memset(rollback_state.backup_path, 0, sizeof(rollback_state.backup_path));
+        fw_rollback_state_remove();
+    }
+
+    /* Generate backup path using mkstemp for safety (comment 6) */
+    /* Try /run/firewallo first, fall back to /tmp */
+    char template[FW_ROLLBACK_BACKUP_PATH_MAX];
+    mkdir(FW_ROLLBACK_STATE_DIR, 0755);
+    snprintf(template, sizeof(template), "%s/.rollback_XXXXXX.json",
+             FW_ROLLBACK_STATE_DIR);
+
+    /* mkstemp needs a mutable template without the .json suffix,
+       so we use mkstemps if available, otherwise manual approach */
+    int fd = -1;
+    /* Use a simple template and rename approach.
+       Reserve 6 bytes for ".json\0" in final_path. */
+    char tmppath[FW_ROLLBACK_BACKUP_PATH_MAX - 5];
+    snprintf(tmppath, sizeof(tmppath), "%s/.rollback_XXXXXX", FW_ROLLBACK_STATE_DIR);
+    fd = mkstemp(tmppath);
+    if (fd < 0) {
+        /* Fall back to /tmp */
+        snprintf(tmppath, sizeof(tmppath), "/tmp/.firewallo_rollback_XXXXXX");
+        fd = mkstemp(tmppath);
+    }
+    if (fd < 0) {
+        fw_log(LOG_ERROR, "rollback: failed to create temp file: %s", strerror(errno));
+        return -1;
+    }
+    close(fd);
+
+    /* Rename to add .json extension */
+    char final_path[FW_ROLLBACK_BACKUP_PATH_MAX];
+    snprintf(final_path, sizeof(final_path), "%s.json", tmppath);
+    rename(tmppath, final_path);
+
+    fw_strlcpy(rollback_state.backup_path, final_path,
+                sizeof(rollback_state.backup_path));
 
     /* Create backup of current config */
     if (fw_config_backup(rollback_cfg_ptr, rollback_state.backup_path) != 0) {
         fw_log(LOG_ERROR, "rollback: failed to create backup at %s",
                rollback_state.backup_path);
+        unlink(rollback_state.backup_path);
         rollback_state.backup_path[0] = '\0';
         return -1;
     }
 
-    /* Set up signal handler */
+    /* Set up signal handler (only sets atomic flag) */
     struct sigaction sa;
     memset(&sa, 0, sizeof(sa));
     sa.sa_handler = sigalrm_handler;
@@ -118,9 +211,17 @@ int fw_rollback_start(int timeout_seconds)
     sigemptyset(&sa.sa_mask);
     sigaction(SIGALRM, &sa, NULL);
 
+    /* Reset the flag */
+    rollback_alarm_fired = 0;
+
     /* Set state */
     rollback_state.pending = 1;
     rollback_state.deadline = time(NULL) + timeout_seconds;
+    fw_strlcpy(rollback_state.config_path, rollback_config_path,
+                sizeof(rollback_state.config_path));
+
+    /* Write state file for cross-process communication (comment 3) */
+    fw_rollback_state_save(&rollback_state);
 
     /* Start the countdown */
     alarm((unsigned int)timeout_seconds);
@@ -129,15 +230,71 @@ int fw_rollback_start(int timeout_seconds)
     return 0;
 }
 
-int fw_rollback_confirm(void)
+/* Perform the actual rollback: stop current rules, load backup, reapply (comment 5) */
+int fw_rollback_perform(void)
 {
-    if (!rollback_state.pending)
+    if (!rollback_state.pending && !rollback_state.backup_path[0]) {
+        /* Try loading from state file */
+        fw_rollback_state_t file_state;
+        if (fw_rollback_state_load(&file_state) == 0 && file_state.pending) {
+            rollback_state = file_state;
+        } else {
+            fw_log(LOG_ERROR, "rollback: no pending rollback to perform");
+            return -1;
+        }
+    }
+
+    fw_log(LOG_WARN, "rollback: performing automatic rollback");
+
+    fw_config_t backup_cfg;
+    char err[256] = {0};
+
+    if (fw_config_load(rollback_state.backup_path, &backup_cfg, err, sizeof(err)) != 0) {
+        fw_log(LOG_ERROR, "rollback: failed to load backup: %s", err);
         return -1;
+    }
 
-    /* Cancel the alarm */
-    alarm(0);
+    /* Stop current rules using the CURRENT running config, not the backup (comment 5) */
+    fw_config_t *current_cfg = rollback_cfg_ptr;
+    if (current_cfg) {
+        fw_cmdlist_t stop_cmds;
+        fw_compile_stop(current_cfg, &stop_cmds);
+        int fail_idx;
+        fw_cmdlist_exec(&stop_cmds, &fail_idx);
+        fw_cmdlist_free(&stop_cmds);
+    } else {
+        /* No in-process config pointer; load config from disk to stop */
+        fw_config_t disk_cfg;
+        char cerr[256] = {0};
+        if (rollback_state.config_path[0] &&
+            fw_config_load(rollback_state.config_path, &disk_cfg, cerr, sizeof(cerr)) == 0) {
+            fw_cmdlist_t stop_cmds;
+            fw_compile_stop(&disk_cfg, &stop_cmds);
+            int fail_idx;
+            fw_cmdlist_exec(&stop_cmds, &fail_idx);
+            fw_cmdlist_free(&stop_cmds);
+        }
+    }
 
-    /* Remove backup file */
+    /* Apply sysctl from backup */
+    fw_sysctl_apply(&backup_cfg);
+
+    /* Recompile and apply backup rules */
+    fw_cmdlist_t start_cmds;
+    fw_compile_start(&backup_cfg, &start_cmds);
+    int fail_idx;
+    fw_cmdlist_exec(&start_cmds, &fail_idx);
+    fw_cmdlist_free(&start_cmds);
+
+    /* Restore the config struct if we have a pointer */
+    if (rollback_cfg_ptr)
+        *rollback_cfg_ptr = backup_cfg;
+
+    /* Save the restored config to disk */
+    if (rollback_state.config_path[0])
+        fw_config_save(rollback_state.config_path, &backup_cfg);
+
+    /* Clean up backup file */
     if (rollback_state.backup_path[0])
         unlink(rollback_state.backup_path);
 
@@ -146,14 +303,85 @@ int fw_rollback_confirm(void)
     rollback_state.deadline = 0;
     memset(rollback_state.backup_path, 0, sizeof(rollback_state.backup_path));
 
-    fw_log(LOG_INFO, "rollback: configuration confirmed, timer cancelled");
+    /* Remove state file */
+    fw_rollback_state_remove();
+
+    fw_log(LOG_INFO, "rollback: configuration rolled back successfully");
     return 0;
+}
+
+int fw_rollback_check(void)
+{
+    if (rollback_alarm_fired) {
+        rollback_alarm_fired = 0;
+        if (rollback_state.pending) {
+            fw_rollback_perform();
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int fw_rollback_confirm(void)
+{
+    /* First check in-process state */
+    if (rollback_state.pending) {
+        /* Cancel the alarm */
+        alarm(0);
+
+        /* Remove backup file */
+        if (rollback_state.backup_path[0])
+            unlink(rollback_state.backup_path);
+
+        /* Reset state */
+        rollback_state.pending = 0;
+        rollback_state.deadline = 0;
+        memset(rollback_state.backup_path, 0, sizeof(rollback_state.backup_path));
+
+        /* Remove state file */
+        fw_rollback_state_remove();
+
+        fw_log(LOG_INFO, "rollback: configuration confirmed, timer cancelled");
+        return 0;
+    }
+
+    /* Cross-process: try state file (comment 3) */
+    fw_rollback_state_t file_state;
+    if (fw_rollback_state_load(&file_state) == 0 && file_state.pending) {
+        /* Check if the deadline has already passed */
+        time_t now = time(NULL);
+        if (now > file_state.deadline) {
+            fw_rollback_state_remove();
+            return -1; /* too late, rollback already happened */
+        }
+
+        /* Remove backup file */
+        if (file_state.backup_path[0])
+            unlink(file_state.backup_path);
+
+        /* Remove state file to signal the waiting process */
+        fw_rollback_state_remove();
+
+        fw_log(LOG_INFO, "rollback: configuration confirmed via state file");
+        return 0;
+    }
+
+    return -1;
 }
 
 int fw_rollback_cancel(void)
 {
-    if (!rollback_state.pending)
+    if (!rollback_state.pending) {
+        /* Try state file */
+        fw_rollback_state_t file_state;
+        if (fw_rollback_state_load(&file_state) == 0 && file_state.pending) {
+            if (file_state.backup_path[0])
+                unlink(file_state.backup_path);
+            fw_rollback_state_remove();
+            return 0;
+        }
         return -1;
+    }
 
     /* Cancel the alarm */
     alarm(0);
@@ -166,6 +394,9 @@ int fw_rollback_cancel(void)
     rollback_state.pending = 0;
     rollback_state.deadline = 0;
     memset(rollback_state.backup_path, 0, sizeof(rollback_state.backup_path));
+
+    /* Remove state file */
+    fw_rollback_state_remove();
 
     fw_log(LOG_INFO, "rollback: timer cancelled");
     return 0;
@@ -176,6 +407,17 @@ int fw_rollback_status(fw_rollback_state_t *state)
     if (!state)
         return -1;
 
-    *state = rollback_state;
+    /* Check in-process state first */
+    if (rollback_state.pending) {
+        *state = rollback_state;
+        return 0;
+    }
+
+    /* Try state file for cross-process queries */
+    if (fw_rollback_state_load(state) == 0)
+        return 0;
+
+    /* No rollback pending */
+    memset(state, 0, sizeof(*state));
     return 0;
 }

--- a/src/lib/rollback.c
+++ b/src/lib/rollback.c
@@ -1,0 +1,181 @@
+#include "firewallo/rollback.h"
+#include "firewallo/config.h"
+#include "firewallo/rule_compiler.h"
+#include "firewallo/sysctl.h"
+#include "firewallo/log.h"
+#include "firewallo/util.h"
+#include <signal.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>
+
+/* ── Static rollback state ────────────────────────────────────────── */
+
+static fw_rollback_state_t rollback_state;
+static fw_config_t *rollback_cfg_ptr;
+static char rollback_config_path[FW_ROLLBACK_BACKUP_PATH_MAX];
+
+/* ── Signal handler for SIGALRM ───────────────────────────────────── */
+
+static void sigalrm_handler(int sig)
+{
+    (void)sig;
+
+    if (!rollback_state.pending)
+        return;
+
+    /* Perform rollback: load backup and reapply rules */
+    if (rollback_cfg_ptr && rollback_state.backup_path[0]) {
+        fw_config_t backup_cfg;
+        char err[256] = {0};
+
+        if (fw_config_load(rollback_state.backup_path, &backup_cfg, err, sizeof(err)) == 0) {
+            /* Stop current rules */
+            fw_cmdlist_t stop_cmds;
+            fw_compile_stop(&backup_cfg, &stop_cmds);
+            int fail_idx;
+            fw_cmdlist_exec(&stop_cmds, &fail_idx);
+            fw_cmdlist_free(&stop_cmds);
+
+            /* Apply sysctl from backup */
+            fw_sysctl_apply(&backup_cfg);
+
+            /* Recompile and apply backup rules */
+            fw_cmdlist_t start_cmds;
+            fw_compile_start(&backup_cfg, &start_cmds);
+            fw_cmdlist_exec(&start_cmds, &fail_idx);
+            fw_cmdlist_free(&start_cmds);
+
+            /* Restore the config struct */
+            *rollback_cfg_ptr = backup_cfg;
+
+            /* Save the restored config to disk */
+            if (rollback_config_path[0])
+                fw_config_save(rollback_config_path, &backup_cfg);
+        }
+
+        /* Clean up backup file */
+        unlink(rollback_state.backup_path);
+    }
+
+    /* Reset state */
+    rollback_state.pending = 0;
+    rollback_state.deadline = 0;
+    memset(rollback_state.backup_path, 0, sizeof(rollback_state.backup_path));
+}
+
+/* ── Public API ───────────────────────────────────────────────────── */
+
+void fw_rollback_set_context(fw_config_t *cfg, const char *config_path)
+{
+    rollback_cfg_ptr = cfg;
+    if (config_path)
+        fw_strlcpy(rollback_config_path, config_path, sizeof(rollback_config_path));
+    else
+        rollback_config_path[0] = '\0';
+}
+
+int fw_config_backup(const fw_config_t *cfg, const char *backup_path)
+{
+    return fw_config_save(backup_path, cfg);
+}
+
+int fw_config_rollback(const char *backup_path, fw_config_t *cfg)
+{
+    char err[256] = {0};
+    if (fw_config_load(backup_path, cfg, err, sizeof(err)) != 0)
+        return -1;
+    return 0;
+}
+
+int fw_rollback_start(int timeout_seconds)
+{
+    if (timeout_seconds <= 0)
+        timeout_seconds = FW_ROLLBACK_DEFAULT_TIMEOUT;
+
+    if (!rollback_cfg_ptr) {
+        fw_log(LOG_ERROR, "rollback: context not set, call fw_rollback_set_context first");
+        return -1;
+    }
+
+    /* Generate backup path */
+    snprintf(rollback_state.backup_path, sizeof(rollback_state.backup_path),
+             "/tmp/.firewallo_rollback_%d.json", (int)getpid());
+
+    /* Create backup of current config */
+    if (fw_config_backup(rollback_cfg_ptr, rollback_state.backup_path) != 0) {
+        fw_log(LOG_ERROR, "rollback: failed to create backup at %s",
+               rollback_state.backup_path);
+        rollback_state.backup_path[0] = '\0';
+        return -1;
+    }
+
+    /* Set up signal handler */
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = sigalrm_handler;
+    sa.sa_flags = 0; /* No SA_RESTART so alarm can interrupt */
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGALRM, &sa, NULL);
+
+    /* Set state */
+    rollback_state.pending = 1;
+    rollback_state.deadline = time(NULL) + timeout_seconds;
+
+    /* Start the countdown */
+    alarm((unsigned int)timeout_seconds);
+
+    fw_log(LOG_INFO, "rollback: timer started, %d seconds to confirm", timeout_seconds);
+    return 0;
+}
+
+int fw_rollback_confirm(void)
+{
+    if (!rollback_state.pending)
+        return -1;
+
+    /* Cancel the alarm */
+    alarm(0);
+
+    /* Remove backup file */
+    if (rollback_state.backup_path[0])
+        unlink(rollback_state.backup_path);
+
+    /* Reset state */
+    rollback_state.pending = 0;
+    rollback_state.deadline = 0;
+    memset(rollback_state.backup_path, 0, sizeof(rollback_state.backup_path));
+
+    fw_log(LOG_INFO, "rollback: configuration confirmed, timer cancelled");
+    return 0;
+}
+
+int fw_rollback_cancel(void)
+{
+    if (!rollback_state.pending)
+        return -1;
+
+    /* Cancel the alarm */
+    alarm(0);
+
+    /* Remove backup file */
+    if (rollback_state.backup_path[0])
+        unlink(rollback_state.backup_path);
+
+    /* Reset state */
+    rollback_state.pending = 0;
+    rollback_state.deadline = 0;
+    memset(rollback_state.backup_path, 0, sizeof(rollback_state.backup_path));
+
+    fw_log(LOG_INFO, "rollback: timer cancelled");
+    return 0;
+}
+
+int fw_rollback_status(fw_rollback_state_t *state)
+{
+    if (!state)
+        return -1;
+
+    *state = rollback_state;
+    return 0;
+}

--- a/src/web/api.c
+++ b/src/web/api.c
@@ -2,6 +2,7 @@
 #include "firewallo/config.h"
 #include "firewallo/json.h"
 #include "firewallo/rule_compiler.h"
+#include "firewallo/rollback.h"
 #include "firewallo/sysctl.h"
 #include "firewallo/validate.h"
 #include "firewallo/util.h"
@@ -11,6 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <time.h>
 
 /* ── Helpers ───────────────────────────────────────────────────────── */
 
@@ -696,6 +698,41 @@ static void api_firewall_preview(httpd_t *srv, http_response_t *resp)
     api_ok_json(resp, data);
 }
 
+/* ── POST /api/v1/firewall/confirm ─────────────────────────────────── */
+
+static void api_firewall_confirm(http_response_t *resp)
+{
+    if (fw_rollback_confirm() != 0) {
+        api_error(resp, 400, "No pending rollback to confirm");
+        return;
+    }
+    api_ok_msg(resp, "Configuration confirmed, rollback timer cancelled");
+}
+
+/* ── GET /api/v1/firewall/rollback-status ──────────────────────────── */
+
+static void api_firewall_rollback_status(http_response_t *resp)
+{
+    fw_rollback_state_t state;
+    fw_rollback_status(&state);
+
+    json_value_t *data = json_new_object();
+    json_object_set(data, "pending", json_new_bool(state.pending));
+
+    if (state.pending) {
+        time_t now = time(NULL);
+        int remaining = (int)(state.deadline - now);
+        if (remaining < 0) remaining = 0;
+        json_object_set(data, "remaining_seconds", json_new_number(remaining));
+        json_object_set(data, "deadline", json_new_number((double)state.deadline));
+    } else {
+        json_object_set(data, "remaining_seconds", json_new_number(0));
+        json_object_set(data, "deadline", json_new_number(0));
+    }
+
+    api_ok_json(resp, data);
+}
+
 /* ── Main API dispatcher ──────────────────────────────────────────── */
 
 int api_handle(httpd_t *srv, const http_request_t *req, http_response_t *resp)
@@ -845,6 +882,14 @@ int api_handle(httpd_t *srv, const http_request_t *req, http_response_t *resp)
         }
         if (strcmp(sub, "preview") == 0 && strcmp(method, "POST") == 0) {
             api_firewall_preview(srv, resp);
+            return 0;
+        }
+        if (strcmp(sub, "confirm") == 0 && strcmp(method, "POST") == 0) {
+            api_firewall_confirm(resp);
+            return 0;
+        }
+        if (strcmp(sub, "rollback-status") == 0 && strcmp(method, "GET") == 0) {
+            api_firewall_rollback_status(resp);
             return 0;
         }
         if (strcmp(method, "POST") == 0) {

--- a/src/web/api.c
+++ b/src/web/api.c
@@ -513,12 +513,38 @@ static void api_get_nat(httpd_t *srv, http_response_t *resp)
 
 /* ── POST /api/v1/firewall/{action} ───────────────────────────────── */
 
-static void api_firewall_action(httpd_t *srv, const char *action, http_response_t *resp)
+static void api_firewall_action(httpd_t *srv, const char *action,
+                                 const http_request_t *req, http_response_t *resp)
 {
+    /* Check for optional rollback_timeout in request body */
+    int rollback_timeout = 0;
+    if (req->body && req->body_len > 0) {
+        char perr[256];
+        json_value_t *body = json_parse(req->body, perr, sizeof(perr));
+        if (body) {
+            json_value_t *tv = json_object_get(body, "rollback_timeout");
+            if (tv && tv->type == JSON_NUMBER)
+                rollback_timeout = (int)json_number_value(tv);
+            json_free(body);
+        }
+    }
+
+    /* Set up rollback for start/restart if requested (comment 2) */
+    int use_rollback = (rollback_timeout > 0 &&
+                        (strcmp(action, "start") == 0 || strcmp(action, "restart") == 0));
+    if (use_rollback) {
+        fw_rollback_set_context(srv->config, srv->config_path);
+        if (fw_rollback_start(rollback_timeout) != 0) {
+            api_error(resp, 500, "Failed to start rollback timer");
+            return;
+        }
+    }
+
     fw_cmdlist_t cmds;
     if (strcmp(action, "start") == 0) {
         char err[256];
         if (fw_config_validate(srv->config, err, sizeof(err)) != 0) {
+            if (use_rollback) fw_rollback_cancel();
             api_error(resp, 400, err);
             return;
         }
@@ -547,14 +573,23 @@ static void api_firewall_action(httpd_t *srv, const char *action, http_response_
     fw_cmdlist_free(&cmds);
 
     if (ret != 0) {
+        if (use_rollback) {
+            fw_rollback_perform();
+        }
         char msg[128];
         snprintf(msg, sizeof(msg), "Command failed at index %d", fail_idx);
         api_error(resp, 500, msg);
         return;
     }
 
-    char msg[64];
-    snprintf(msg, sizeof(msg), "Firewall %s completed", action);
+    char msg[128];
+    if (use_rollback) {
+        snprintf(msg, sizeof(msg),
+                 "Firewall %s completed, confirm within %d seconds",
+                 action, rollback_timeout);
+    } else {
+        snprintf(msg, sizeof(msg), "Firewall %s completed", action);
+    }
     api_ok_msg(resp, msg);
 }
 
@@ -896,7 +931,7 @@ int api_handle(httpd_t *srv, const http_request_t *req, http_response_t *resp)
             /* sub is start/stop/restart/reset */
             char action[16];
             fw_strlcpy(action, sub, sizeof(action));
-            api_firewall_action(srv, action, resp);
+            api_firewall_action(srv, action, req, resp);
             return 0;
         }
     }

--- a/tests/test_rollback.c
+++ b/tests/test_rollback.c
@@ -1,0 +1,318 @@
+#include "firewallo/rollback.h"
+#include "firewallo/config.h"
+#include "firewallo/util.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define ASSERT(cond, msg) do { \
+    tests_run++; \
+    if (!(cond)) { \
+        printf("  FAIL: %s (line %d)\n", msg, __LINE__); \
+    } else { \
+        tests_passed++; \
+    } \
+} while(0)
+
+/* ── Test state file I/O ──────────────────────────────────────────── */
+
+static void test_state_file_save_load(void)
+{
+    printf("test_state_file_save_load\n");
+
+    fw_rollback_state_t state;
+    memset(&state, 0, sizeof(state));
+    state.pending = 1;
+    state.deadline = 1700000000;
+    fw_strlcpy(state.backup_path, "/tmp/test_backup.json", sizeof(state.backup_path));
+    fw_strlcpy(state.config_path, "/etc/firewallo/firewallo.json", sizeof(state.config_path));
+
+    int ret = fw_rollback_state_save(&state);
+    ASSERT(ret == 0, "state save succeeds");
+
+    fw_rollback_state_t loaded;
+    ret = fw_rollback_state_load(&loaded);
+    ASSERT(ret == 0, "state load succeeds");
+    ASSERT(loaded.pending == 1, "pending preserved");
+    ASSERT(loaded.deadline == 1700000000, "deadline preserved");
+    ASSERT(strcmp(loaded.backup_path, "/tmp/test_backup.json") == 0, "backup_path preserved");
+    ASSERT(strcmp(loaded.config_path, "/etc/firewallo/firewallo.json") == 0, "config_path preserved");
+
+    fw_rollback_state_remove();
+}
+
+static void test_state_file_load_missing(void)
+{
+    printf("test_state_file_load_missing\n");
+
+    /* Ensure no state file */
+    fw_rollback_state_remove();
+
+    fw_rollback_state_t state;
+    int ret = fw_rollback_state_load(&state);
+    ASSERT(ret == -1, "load returns -1 when no file");
+}
+
+static void test_state_file_remove(void)
+{
+    printf("test_state_file_remove\n");
+
+    fw_rollback_state_t state;
+    memset(&state, 0, sizeof(state));
+    state.pending = 1;
+    state.deadline = 1700000000;
+    fw_rollback_state_save(&state);
+
+    /* Verify file can be loaded (it exists somewhere) */
+    fw_rollback_state_t loaded;
+    int can_load = fw_rollback_state_load(&loaded) == 0;
+    ASSERT(can_load, "state file exists after save");
+
+    fw_rollback_state_remove();
+
+    can_load = fw_rollback_state_load(&loaded) == 0;
+    ASSERT(!can_load, "state file removed");
+}
+
+/* ── Test backup and rollback functions ───────────────────────────── */
+
+static void test_config_backup_and_rollback(void)
+{
+    printf("test_config_backup_and_rollback\n");
+
+    fw_config_t cfg;
+    char err[256] = {0};
+    int ret = fw_config_load("tests/fixtures/minimal.json", &cfg, err, sizeof(err));
+    ASSERT(ret == 0, "load config for backup test");
+
+    const char *backup = "/tmp/firewallo_test_backup.json";
+
+    ret = fw_config_backup(&cfg, backup);
+    ASSERT(ret == 0, "backup succeeds");
+
+    /* Verify backup file exists */
+    struct stat st;
+    ASSERT(stat(backup, &st) == 0, "backup file exists");
+
+    /* Modify config */
+    cfg.ip_forward = 0;
+    fw_strlcpy(cfg.version, "9.9.9", sizeof(cfg.version));
+
+    /* Rollback */
+    ret = fw_config_rollback(backup, &cfg);
+    ASSERT(ret == 0, "rollback succeeds");
+    ASSERT(cfg.ip_forward == 1, "ip_forward restored");
+    ASSERT(strcmp(cfg.version, "2.0.0") == 0, "version restored");
+
+    unlink(backup);
+}
+
+/* ── Test rollback start and confirm ──────────────────────────────── */
+
+static void test_rollback_start_confirm(void)
+{
+    printf("test_rollback_start_confirm\n");
+
+    fw_config_t cfg;
+    char err[256] = {0};
+    int ret = fw_config_load("tests/fixtures/minimal.json", &cfg, err, sizeof(err));
+    ASSERT(ret == 0, "load config for rollback test");
+
+    fw_rollback_set_context(&cfg, "/tmp/firewallo_test_rollback_cfg.json");
+
+    /* Save config to disk so rollback can work */
+    fw_config_save("/tmp/firewallo_test_rollback_cfg.json", &cfg);
+
+    ret = fw_rollback_start(30);
+    ASSERT(ret == 0, "rollback start succeeds");
+
+    /* Check state */
+    fw_rollback_state_t state;
+    fw_rollback_status(&state);
+    ASSERT(state.pending == 1, "rollback is pending");
+    ASSERT(state.backup_path[0] != '\0', "backup path is set");
+
+    /* Confirm */
+    ret = fw_rollback_confirm();
+    ASSERT(ret == 0, "confirm succeeds");
+
+    fw_rollback_status(&state);
+    ASSERT(state.pending == 0, "rollback no longer pending after confirm");
+
+    /* Clean up */
+    unlink("/tmp/firewallo_test_rollback_cfg.json");
+}
+
+/* ── Test rollback start and cancel ───────────────────────────────── */
+
+static void test_rollback_start_cancel(void)
+{
+    printf("test_rollback_start_cancel\n");
+
+    fw_config_t cfg;
+    char err[256] = {0};
+    int ret = fw_config_load("tests/fixtures/minimal.json", &cfg, err, sizeof(err));
+    ASSERT(ret == 0, "load config for cancel test");
+
+    fw_rollback_set_context(&cfg, "/tmp/firewallo_test_cancel_cfg.json");
+    fw_config_save("/tmp/firewallo_test_cancel_cfg.json", &cfg);
+
+    ret = fw_rollback_start(30);
+    ASSERT(ret == 0, "rollback start succeeds");
+
+    ret = fw_rollback_cancel();
+    ASSERT(ret == 0, "cancel succeeds");
+
+    fw_rollback_state_t state;
+    fw_rollback_status(&state);
+    ASSERT(state.pending == 0, "rollback not pending after cancel");
+
+    unlink("/tmp/firewallo_test_cancel_cfg.json");
+}
+
+/* ── Test confirm without pending rollback ─────────────────────────── */
+
+static void test_confirm_no_pending(void)
+{
+    printf("test_confirm_no_pending\n");
+
+    /* Make sure no state file exists */
+    fw_rollback_state_remove();
+
+    int ret = fw_rollback_confirm();
+    ASSERT(ret == -1, "confirm returns -1 when nothing pending");
+}
+
+/* ── Test cancel without pending rollback ──────────────────────────── */
+
+static void test_cancel_no_pending(void)
+{
+    printf("test_cancel_no_pending\n");
+
+    fw_rollback_state_remove();
+
+    int ret = fw_rollback_cancel();
+    ASSERT(ret == -1, "cancel returns -1 when nothing pending");
+}
+
+/* ── Test rollback status ──────────────────────────────────────────── */
+
+static void test_status_null(void)
+{
+    printf("test_status_null\n");
+
+    int ret = fw_rollback_status(NULL);
+    ASSERT(ret == -1, "status returns -1 for null");
+}
+
+/* ── Test already-pending rollback cleanup ─────────────────────────── */
+
+static void test_already_pending_cleanup(void)
+{
+    printf("test_already_pending_cleanup\n");
+
+    fw_config_t cfg;
+    char err[256] = {0};
+    int ret = fw_config_load("tests/fixtures/minimal.json", &cfg, err, sizeof(err));
+    ASSERT(ret == 0, "load config for already-pending test");
+
+    fw_rollback_set_context(&cfg, "/tmp/firewallo_test_pending_cfg.json");
+    fw_config_save("/tmp/firewallo_test_pending_cfg.json", &cfg);
+
+    /* Start first rollback */
+    ret = fw_rollback_start(30);
+    ASSERT(ret == 0, "first rollback start succeeds");
+
+    fw_rollback_state_t state1;
+    fw_rollback_status(&state1);
+    char first_backup[FW_ROLLBACK_BACKUP_PATH_MAX];
+    fw_strlcpy(first_backup, state1.backup_path, sizeof(first_backup));
+
+    /* Start second rollback (should clean up the first) */
+    ret = fw_rollback_start(60);
+    ASSERT(ret == 0, "second rollback start succeeds");
+
+    /* First backup file should be cleaned up */
+    struct stat st;
+    ASSERT(stat(first_backup, &st) != 0, "first backup file was cleaned up");
+
+    /* Confirm the second one */
+    fw_rollback_confirm();
+
+    unlink("/tmp/firewallo_test_pending_cfg.json");
+}
+
+/* ── Test cross-process confirm via state file ─────────────────────── */
+
+static void test_cross_process_state_file(void)
+{
+    printf("test_cross_process_state_file\n");
+
+    /* Simulate: write a state file as if another process started rollback */
+    fw_rollback_state_t state;
+    memset(&state, 0, sizeof(state));
+    state.pending = 1;
+    state.deadline = time(NULL) + 300; /* far future */
+    fw_strlcpy(state.backup_path, "/tmp/firewallo_test_xprocess.json", sizeof(state.backup_path));
+    fw_strlcpy(state.config_path, "/tmp/firewallo_test_xprocess_cfg.json", sizeof(state.config_path));
+
+    /* Create a dummy backup file */
+    fw_config_t cfg;
+    char err[256] = {0};
+    fw_config_load("tests/fixtures/minimal.json", &cfg, err, sizeof(err));
+    fw_config_save("/tmp/firewallo_test_xprocess.json", &cfg);
+
+    fw_rollback_state_save(&state);
+
+    /* Now "confirm" from a different process context (no in-process state) */
+    int ret = fw_rollback_confirm();
+    ASSERT(ret == 0, "cross-process confirm succeeds via state file");
+
+    /* State file should be gone */
+    fw_rollback_state_t loaded;
+    ret = fw_rollback_state_load(&loaded);
+    ASSERT(ret == -1 || !loaded.pending, "state file removed after confirm");
+
+    /* Clean up */
+    unlink("/tmp/firewallo_test_xprocess.json");
+    unlink("/tmp/firewallo_test_xprocess_cfg.json");
+}
+
+/* ── Test fw_rollback_check without alarm ──────────────────────────── */
+
+static void test_rollback_check_no_alarm(void)
+{
+    printf("test_rollback_check_no_alarm\n");
+
+    /* Should return 0 when no alarm has fired */
+    int ret = fw_rollback_check();
+    ASSERT(ret == 0, "check returns 0 when no alarm");
+}
+
+/* ── Main ──────────────────────────────────────────────────────────── */
+
+int main(void)
+{
+    printf("=== Rollback Tests ===\n\n");
+
+    test_state_file_save_load();
+    test_state_file_load_missing();
+    test_state_file_remove();
+    test_config_backup_and_rollback();
+    test_rollback_start_confirm();
+    test_rollback_start_cancel();
+    test_confirm_no_pending();
+    test_cancel_no_pending();
+    test_status_null();
+    test_already_pending_cleanup();
+    test_cross_process_state_file();
+    test_rollback_check_no_alarm();
+
+    printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+    return tests_passed == tests_run ? 0 : 1;
+}


### PR DESCRIPTION
## Task FW-0001 — Automatic rollback timer for safe rule application

### Summary
- Created `src/lib/rollback.c` and `include/firewallo/rollback.h` with backup/restore/timer mechanism
- Added `confirm` CLI command and `--rollback-timeout` flag
- Added REST API endpoints for confirm and rollback status
- Updated Makefile

### Related Issue
Refs #39 (FW-0001)

---
*Generated by Claude Code via `/task-pick`*