### PR TITLE
[FW-0002] Rate limiting and dynamic brute-force protection

### DIFF
--- a/include/firewallo/backend.h
+++ b/include/firewallo/backend.h
@@ -60,6 +60,10 @@ typedef struct {
     /* Mangle table setup */
     void (*create_mangle_table)(fw_cmdlist_t *out);
 
+    /* Rate limiting */
+    void (*add_rate_limit)(fw_cmdlist_t *out, const char *chain,
+                           const fw_rate_limit_t *rl);
+
     /* Stop/Reset */
     void (*setup_stop)(fw_cmdlist_t *out);
     void (*setup_reset)(fw_cmdlist_t *out);

--- a/include/firewallo/types.h
+++ b/include/firewallo/types.h
@@ -78,6 +78,14 @@ typedef struct {
     char comment[FW_MAX_COMMENT];
 } fw_filter_rule_t;
 
+/* Rate limit configuration for brute-force protection */
+typedef struct {
+    int max_connections;
+    int period_seconds;
+    int ban_seconds;
+    int enabled;
+} fw_rate_limit_t;
+
 /* A filter chain (one of 25) */
 typedef struct {
     char name[16];
@@ -87,6 +95,7 @@ typedef struct {
     int udp_port_count;
     fw_filter_rule_t rules[FW_MAX_RULES];
     int rule_count;
+    fw_rate_limit_t rate_limit;
 } fw_chain_t;
 
 /* NAT postrouting rule (MASQUERADE / SNAT) */

--- a/src/cli/commands.c
+++ b/src/cli/commands.c
@@ -886,6 +886,50 @@ int cmd_preview(fw_config_t *cfg, const char *config_path)
     return 0;
 }
 
+/* ── Set rate limit ────────────────────────────────────────────────── */
+
+int cmd_set_ratelimit(fw_config_t *cfg, const char *chain, const char *max_str,
+                      const char *period_str, const char *ban_str,
+                      const char *config_path)
+{
+    int idx = fw_config_chain_index(chain);
+    if (idx < 0) {
+        fprintf(stderr, "Unknown chain: %s\n", chain);
+        return 1;
+    }
+
+    char *endptr;
+    long max_l = strtol(max_str, &endptr, 10);
+    if (*endptr != '\0' || max_l <= 0) {
+        fprintf(stderr, "Invalid max_connections: %s (must be positive integer)\n", max_str);
+        return 1;
+    }
+
+    long period_l = strtol(period_str, &endptr, 10);
+    if (*endptr != '\0' || period_l <= 0) {
+        fprintf(stderr, "Invalid period_seconds: %s (must be positive integer)\n", period_str);
+        return 1;
+    }
+
+    long ban_l = strtol(ban_str, &endptr, 10);
+    if (*endptr != '\0' || ban_l <= 0) {
+        fprintf(stderr, "Invalid ban_seconds: %s (must be positive integer)\n", ban_str);
+        return 1;
+    }
+
+    cfg->chains[idx].rate_limit.max_connections = (int)max_l;
+    cfg->chains[idx].rate_limit.period_seconds = (int)period_l;
+    cfg->chains[idx].rate_limit.ban_seconds = (int)ban_l;
+    cfg->chains[idx].rate_limit.enabled = 1;
+
+    if (validate_and_save(cfg, config_path) != 0)
+        return 1;
+
+    printf("Rate limit set on %s: max=%d period=%ds ban=%ds\n",
+           chain, (int)max_l, (int)period_l, (int)ban_l);
+    return 0;
+}
+
 /* ── Reload ────────────────────────────────────────────────────────── */
 
 int cmd_reload(fw_config_t *cfg, const char *config_path, int verbose)

--- a/src/cli/commands.h
+++ b/src/cli/commands.h
@@ -31,5 +31,8 @@ int cmd_set_nat(fw_config_t *cfg, const char *direction, const char *action,
                 const char *rule_json, const char *config_path);
 int cmd_reload(fw_config_t *cfg, const char *config_path, int verbose);
 int cmd_preview(fw_config_t *cfg, const char *config_path);
+int cmd_set_ratelimit(fw_config_t *cfg, const char *chain, const char *max_str,
+                      const char *period_str, const char *ban_str,
+                      const char *config_path);
 
 #endif /* FIREWALLO_CLI_COMMANDS_H */

--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -36,6 +36,7 @@ static void print_usage(void)
         "  set-sysctl <key> <0|1>\n"
         "  set-chain <chain> <tcp|udp> <add|remove> <port>\n"
         "  set-nat <post|pre> <add|remove> <rule-json>\n"
+        "  set-ratelimit <chain> <max> <period> <ban>\n"
         "\n"
         "Options:\n"
         "  -c, --config <path>  Config file (default: /etc/firewallo/firewallo.json)\n"
@@ -205,6 +206,13 @@ int main(int argc, char *argv[])
         }
         ret = cmd_set_nat(&cfg, argv[optind + 1], argv[optind + 2],
                           argv[optind + 3], config_path);
+    } else if (strcmp(command, "set-ratelimit") == 0) {
+        if (optind + 4 >= argc) {
+            fprintf(stderr, "Usage: firewallo set-ratelimit <chain> <max> <period> <ban>\n");
+            return 1;
+        }
+        ret = cmd_set_ratelimit(&cfg, argv[optind + 1], argv[optind + 2],
+                                argv[optind + 3], argv[optind + 4], config_path);
     } else if (strcmp(command, "version") == 0)
         ret = cmd_version(&cfg);
     else {

--- a/src/lib/backend_ipt.c
+++ b/src/lib/backend_ipt.c
@@ -326,6 +326,49 @@ static void ipt_create_mangle_table(fw_cmdlist_t *out)
     (void)out; /* iptables mangle table exists by default */
 }
 
+/* ── Rate limiting ─────────────────────────────────────────────────── */
+
+static void ipt_add_rate_limit(fw_cmdlist_t *out, const char *chain,
+                                const fw_rate_limit_t *rl)
+{
+    if (!rl || !rl->enabled)
+        return;
+
+    /* Use the 'recent' module for brute-force protection:
+     * 1. Drop packets from IPs already on the ban list within the ban window
+     * 2. Track new connections and add to ban list if rate exceeded */
+
+    /* Drop from IPs on the recent list that exceeded the rate within ban_seconds */
+    fw_cmdlist_append(out,
+        "%s -A %s -m recent --name ratelimit_%s --rcheck "
+        "--seconds %d --hitcount %d "
+        "-j LOG --log-prefix \"RATELIMIT BAN %s :\"",
+        IPT, chain, chain, rl->ban_seconds, rl->max_connections + 1, chain);
+    fw_cmdlist_append(out,
+        "%s -A %s -m recent --name ratelimit_%s --rcheck "
+        "--seconds %d --hitcount %d -j DROP",
+        IPT, chain, chain, rl->ban_seconds, rl->max_connections + 1);
+
+    /* Track new connections with the recent module */
+    fw_cmdlist_append(out,
+        "%s -A %s -m state --state NEW "
+        "-m recent --name ratelimit_%s --set",
+        IPT, chain, chain);
+
+    /* Drop if rate exceeded within the period */
+    fw_cmdlist_append(out,
+        "%s -A %s -m state --state NEW "
+        "-m recent --name ratelimit_%s --update "
+        "--seconds %d --hitcount %d "
+        "-j LOG --log-prefix \"RATELIMIT ADD %s :\"",
+        IPT, chain, chain, rl->period_seconds, rl->max_connections + 1, chain);
+    fw_cmdlist_append(out,
+        "%s -A %s -m state --state NEW "
+        "-m recent --name ratelimit_%s --update "
+        "--seconds %d --hitcount %d -j DROP",
+        IPT, chain, chain, rl->period_seconds, rl->max_connections + 1);
+}
+
 /* ── Stop / Reset ──────────────────────────────────────────────────── */
 
 static void ipt_setup_stop(fw_cmdlist_t *out)
@@ -371,6 +414,7 @@ const fw_backend_ops_t fw_backend_ipt = {
     .add_snat             = ipt_add_snat,
     .add_dnat             = ipt_add_dnat,
     .create_mangle_table  = ipt_create_mangle_table,
+    .add_rate_limit       = ipt_add_rate_limit,
     .setup_stop           = ipt_setup_stop,
     .setup_reset          = ipt_setup_reset,
 };

--- a/src/lib/backend_ipt.c
+++ b/src/lib/backend_ipt.c
@@ -349,10 +349,12 @@ static void ipt_add_rate_limit(fw_cmdlist_t *out, const char *chain,
         "--seconds %d --hitcount %d -j DROP",
         IPT, chain, chain, rl->ban_seconds, rl->max_connections + 1);
 
-    /* Track new connections with the recent module */
+    /* Track new connections with the recent module.
+     * --set must have a terminating target; RETURN continues normal
+     * chain evaluation after marking the source address. */
     fw_cmdlist_append(out,
         "%s -A %s -m state --state NEW "
-        "-m recent --name ratelimit_%s --set",
+        "-m recent --name ratelimit_%s --set -j RETURN",
         IPT, chain, chain);
 
     /* Drop if rate exceeded within the period */

--- a/src/lib/backend_nft.c
+++ b/src/lib/backend_nft.c
@@ -342,15 +342,34 @@ static void nft_add_rate_limit(fw_cmdlist_t *out, const char *chain,
              chain, chain, chain);
     nft_cmd(out, rule);
 
-    /* Add IPs exceeding the rate to the ban set */
+    /* Use a meter keyed on ip saddr so rate limiting is per-source-IP.
+     * Compute an equivalent rate+unit that respects period_seconds:
+     *   - period <= 1s   -> rate/second
+     *   - period <= 60s  -> (max * 60/period)/minute
+     *   - otherwise      -> (max * 3600/period)/hour
+     * This preserves the configured semantics instead of collapsing
+     * arbitrary periods into a single unit. */
+    const char *unit;
+    int rate;
+    if (rl->period_seconds <= 1) {
+        rate = rl->max_connections;
+        unit = "second";
+    } else if (rl->period_seconds <= 60) {
+        rate = rl->max_connections * 60 / rl->period_seconds;
+        if (rate < 1) rate = 1;
+        unit = "minute";
+    } else {
+        rate = rl->max_connections * 3600 / rl->period_seconds;
+        if (rate < 1) rate = 1;
+        unit = "hour";
+    }
+
     snprintf(rule, sizeof(rule),
              "add rule ip filter %s ct state new "
-             "limit rate over %d/%s burst %d packets "
+             "meter ratelimit_meter_%s { ip saddr limit rate over %d/%s burst %d packets } "
              "add @ratelimit_%s { ip saddr } "
              "log prefix \\\"RATELIMIT ADD %s : \\\" counter drop",
-             chain, rl->max_connections,
-             rl->period_seconds <= 1 ? "second" :
-             rl->period_seconds <= 60 ? "minute" : "hour",
+             chain, chain, rate, unit,
              rl->max_connections, chain, chain);
     nft_cmd(out, rule);
 }

--- a/src/lib/backend_nft.c
+++ b/src/lib/backend_nft.c
@@ -319,6 +319,42 @@ static void nft_create_mangle_table(fw_cmdlist_t *out)
     nft_cmd(out, "add chain ip mangle POSTROUTING { type filter hook postrouting priority 150; policy accept; }");
 }
 
+/* ── Rate limiting ─────────────────────────────────────────────────── */
+
+static void nft_add_rate_limit(fw_cmdlist_t *out, const char *chain,
+                                const fw_rate_limit_t *rl)
+{
+    if (!rl || !rl->enabled)
+        return;
+
+    char rule[512];
+
+    /* Create a dynamic set for banned IPs with automatic timeout */
+    snprintf(rule, sizeof(rule),
+             "add set ip filter ratelimit_%s { type ipv4_addr; flags dynamic,timeout; timeout %ds; }",
+             chain, rl->ban_seconds);
+    nft_cmd(out, rule);
+
+    /* Drop packets from IPs already in the ban set */
+    snprintf(rule, sizeof(rule),
+             "add rule ip filter %s ip saddr @ratelimit_%s "
+             "log prefix \\\"RATELIMIT BAN %s : \\\" counter drop",
+             chain, chain, chain);
+    nft_cmd(out, rule);
+
+    /* Add IPs exceeding the rate to the ban set */
+    snprintf(rule, sizeof(rule),
+             "add rule ip filter %s ct state new "
+             "limit rate over %d/%s burst %d packets "
+             "add @ratelimit_%s { ip saddr } "
+             "log prefix \\\"RATELIMIT ADD %s : \\\" counter drop",
+             chain, rl->max_connections,
+             rl->period_seconds <= 1 ? "second" :
+             rl->period_seconds <= 60 ? "minute" : "hour",
+             rl->max_connections, chain, chain);
+    nft_cmd(out, rule);
+}
+
 /* ── Stop / Reset ──────────────────────────────────────────────────── */
 
 static void nft_setup_stop(fw_cmdlist_t *out)
@@ -372,6 +408,7 @@ const fw_backend_ops_t fw_backend_nft = {
     .add_snat             = nft_add_snat,
     .add_dnat             = nft_add_dnat,
     .create_mangle_table  = nft_create_mangle_table,
+    .add_rate_limit       = nft_add_rate_limit,
     .setup_stop           = nft_setup_stop,
     .setup_reset          = nft_setup_reset,
 };

--- a/src/lib/config.c
+++ b/src/lib/config.c
@@ -412,6 +412,23 @@ int fw_config_load(const char *path, fw_config_t *cfg, char *err, size_t errlen)
                            cfg->chains[i].udp_ports, &cfg->chains[i].udp_port_count, FW_MAX_PORTS);
             load_filter_rules(json_object_get(chain, "rules"),
                               cfg->chains[i].rules, &cfg->chains[i].rule_count, FW_MAX_RULES);
+
+            /* Rate limit */
+            json_value_t *rl = json_object_get(chain, "rate_limit");
+            if (rl && rl->type == JSON_OBJECT) {
+                json_value_t *v;
+                v = json_object_get(rl, "enabled");
+                if (v) cfg->chains[i].rate_limit.enabled = json_bool_value(v);
+                v = json_object_get(rl, "max");
+                if (v && v->type == JSON_NUMBER)
+                    cfg->chains[i].rate_limit.max_connections = (int)json_number_value(v);
+                v = json_object_get(rl, "period");
+                if (v && v->type == JSON_NUMBER)
+                    cfg->chains[i].rate_limit.period_seconds = (int)json_number_value(v);
+                v = json_object_get(rl, "ban");
+                if (v && v->type == JSON_NUMBER)
+                    cfg->chains[i].rate_limit.ban_seconds = (int)json_number_value(v);
+            }
         }
     }
 
@@ -685,6 +702,15 @@ static json_value_t *config_to_json(const fw_config_t *cfg)
                         build_int_array((int *)ch->udp_ports, ch->udp_port_count));
         json_object_set(chain, "rules",
                         build_filter_rules(ch->rules, ch->rule_count));
+
+        /* Rate limit */
+        json_value_t *rl = json_new_object();
+        json_object_set(rl, "enabled", json_new_bool(ch->rate_limit.enabled));
+        json_object_set(rl, "max", json_new_number(ch->rate_limit.max_connections));
+        json_object_set(rl, "period", json_new_number(ch->rate_limit.period_seconds));
+        json_object_set(rl, "ban", json_new_number(ch->rate_limit.ban_seconds));
+        json_object_set(chain, "rate_limit", rl);
+
         json_object_set(filter, json_chain_keys[i], chain);
     }
     json_object_set(root, "filter", filter);
@@ -874,7 +900,7 @@ int fw_config_validate(const fw_config_t *cfg, char *err, size_t errlen)
         }
     }
 
-    /* Validate ports and filter rules in all chains */
+    /* Validate ports, filter rules, and rate limits in all chains */
     for (int c = 0; c < FW_CHAIN_COUNT; c++) {
         const fw_chain_t *ch = &cfg->chains[c];
         for (int i = 0; i < ch->tcp_port_count; i++) {
@@ -907,6 +933,25 @@ int fw_config_validate(const fw_config_t *cfg, char *err, size_t errlen)
             if (!fw_validate_comment(r->comment)) {
                 snprintf(err, errlen, "invalid comment in chain %s rule %d",
                          ch->name, i);
+                return -1;
+            }
+        }
+
+        /* Validate rate limit if enabled */
+        if (ch->rate_limit.enabled) {
+            if (ch->rate_limit.max_connections <= 0) {
+                snprintf(err, errlen,
+                         "rate_limit.max must be positive in chain %s", ch->name);
+                return -1;
+            }
+            if (ch->rate_limit.period_seconds <= 0) {
+                snprintf(err, errlen,
+                         "rate_limit.period must be positive in chain %s", ch->name);
+                return -1;
+            }
+            if (ch->rate_limit.ban_seconds <= 0) {
+                snprintf(err, errlen,
+                         "rate_limit.ban must be positive in chain %s", ch->name);
                 return -1;
             }
         }

--- a/src/lib/rule_compiler.c
+++ b/src/lib/rule_compiler.c
@@ -256,9 +256,15 @@ int fw_compile_start(const fw_config_t *cfg, fw_cmdlist_t *out)
         for (int v2 = 0; v2 < vpn_count; v2++)
             ops->add_forward_jump(out, vpn_ifs[v1], vpn_ifs[v2], "vpns2vpns");
 
-    /* 18. Apply filter port rules for all 25 chains */
+    /* 18. Apply rate limits and filter port rules for all 25 chains */
     for (int c = 0; c < FW_CHAIN_COUNT; c++) {
         const fw_chain_t *ch = &cfg->chains[c];
+
+        /* Rate limiting rules come before port rules so offending IPs
+         * are dropped before any accept rules are evaluated */
+        if (ch->rate_limit.enabled)
+            ops->add_rate_limit(out, ch->name, &ch->rate_limit);
+
         for (int i = 0; i < ch->tcp_port_count; i++)
             ops->add_filter_port_rule(out, ch->name, PROTO_TCP, ch->tcp_ports[i]);
         for (int i = 0; i < ch->udp_port_count; i++)

--- a/src/web/api.c
+++ b/src/web/api.c
@@ -371,6 +371,24 @@ static void api_put_ratelimit(httpd_t *srv, const char *chain_name,
 
     json_free(body);
 
+    /* When enabling, validate that all required fields have valid values,
+     * even if they were not supplied in this request (they may have been
+     * left at zero from a previous disabled state). */
+    if (rl->enabled) {
+        if (rl->max_connections <= 0) {
+            api_error(resp, 400, "max must be positive when enabled");
+            return;
+        }
+        if (rl->period_seconds <= 0) {
+            api_error(resp, 400, "period must be positive when enabled");
+            return;
+        }
+        if (rl->ban_seconds <= 0) {
+            api_error(resp, 400, "ban must be positive when enabled");
+            return;
+        }
+    }
+
     if (save_config(srv, resp) != 0) return;
     api_ok_msg(resp, "Rate limit updated");
 }

--- a/src/web/api.c
+++ b/src/web/api.c
@@ -300,6 +300,81 @@ static void api_get_filter_chain(httpd_t *srv, const char *chain_name, http_resp
     api_ok_json(resp, data);
 }
 
+/* ── GET /api/v1/filter/{chain}/ratelimit ───────────────────────────── */
+
+static void api_get_ratelimit(httpd_t *srv, const char *chain_name, http_response_t *resp)
+{
+    int idx = fw_config_chain_index(chain_name);
+    if (idx < 0) { api_error(resp, 404, "Chain not found"); return; }
+
+    const fw_rate_limit_t *rl = &srv->config->chains[idx].rate_limit;
+    json_value_t *data = json_new_object();
+    json_object_set(data, "enabled", json_new_bool(rl->enabled));
+    json_object_set(data, "max", json_new_number(rl->max_connections));
+    json_object_set(data, "period", json_new_number(rl->period_seconds));
+    json_object_set(data, "ban", json_new_number(rl->ban_seconds));
+    api_ok_json(resp, data);
+}
+
+/* ── PUT /api/v1/filter/{chain}/ratelimit ──────────────────────────── */
+
+static void api_put_ratelimit(httpd_t *srv, const char *chain_name,
+                               const http_request_t *req, http_response_t *resp)
+{
+    int idx = fw_config_chain_index(chain_name);
+    if (idx < 0) { api_error(resp, 404, "Chain not found"); return; }
+
+    if (!req->body) { api_error(resp, 400, "Empty body"); return; }
+
+    char err[256];
+    json_value_t *body = json_parse(req->body, err, sizeof(err));
+    if (!body) { api_error(resp, 400, "Invalid JSON"); return; }
+
+    fw_rate_limit_t *rl = &srv->config->chains[idx].rate_limit;
+
+    json_value_t *v;
+    v = json_object_get(body, "enabled");
+    if (v) rl->enabled = json_bool_value(v);
+
+    v = json_object_get(body, "max");
+    if (v && v->type == JSON_NUMBER) {
+        int val = (int)json_number_value(v);
+        if (val <= 0 && rl->enabled) {
+            json_free(body);
+            api_error(resp, 400, "max must be positive when enabled");
+            return;
+        }
+        rl->max_connections = val;
+    }
+
+    v = json_object_get(body, "period");
+    if (v && v->type == JSON_NUMBER) {
+        int val = (int)json_number_value(v);
+        if (val <= 0 && rl->enabled) {
+            json_free(body);
+            api_error(resp, 400, "period must be positive when enabled");
+            return;
+        }
+        rl->period_seconds = val;
+    }
+
+    v = json_object_get(body, "ban");
+    if (v && v->type == JSON_NUMBER) {
+        int val = (int)json_number_value(v);
+        if (val <= 0 && rl->enabled) {
+            json_free(body);
+            api_error(resp, 400, "ban must be positive when enabled");
+            return;
+        }
+        rl->ban_seconds = val;
+    }
+
+    json_free(body);
+
+    if (save_config(srv, resp) != 0) return;
+    api_ok_msg(resp, "Rate limit updated");
+}
+
 /* ── POST /api/v1/filter/{chain}/tcp ───────────────────────────────── */
 
 static void api_add_port(httpd_t *srv, const char *chain_name,
@@ -674,6 +749,17 @@ int api_handle(httpd_t *srv, const http_request_t *req, http_response_t *resp)
         chain_name[clen] = '\0';
 
         const char *resource = slash + 1;
+
+        /* GET/PUT /api/v1/filter/{chain}/ratelimit */
+        if (strcmp(resource, "ratelimit") == 0) {
+            if (strcmp(method, "GET") == 0)
+                api_get_ratelimit(srv, chain_name, resp);
+            else if (strcmp(method, "PUT") == 0)
+                api_put_ratelimit(srv, chain_name, req, resp);
+            else
+                api_error(resp, 405, "Method not allowed");
+            return 0;
+        }
 
         /* POST /api/v1/filter/{chain}/tcp */
         if (strcmp(resource, "tcp") == 0 && strcmp(method, "POST") == 0) {

--- a/tests/test_rule_compiler.c
+++ b/tests/test_rule_compiler.c
@@ -256,6 +256,181 @@ static void test_compile_full_config(void)
     fw_cmdlist_free(&out);
 }
 
+static void test_compile_rate_limit_nft(void)
+{
+    printf("test_compile_rate_limit_nft\n");
+    fw_config_t cfg;
+    char err[256];
+    int ret = fw_config_load("tests/fixtures/minimal.json", &cfg, err, sizeof(err));
+    ASSERT(ret == 0, "load config");
+    ASSERT(cfg.backend == BACKEND_NFT, "backend is nft");
+
+    /* Enable rate limiting on wan2fw chain */
+    int idx = fw_config_chain_index("wan2fw");
+    ASSERT(idx >= 0, "wan2fw chain exists");
+    cfg.chains[idx].rate_limit.enabled = 1;
+    cfg.chains[idx].rate_limit.max_connections = 5;
+    cfg.chains[idx].rate_limit.period_seconds = 60;
+    cfg.chains[idx].rate_limit.ban_seconds = 300;
+
+    fw_cmdlist_t out;
+    ret = fw_compile_start(&cfg, &out);
+    ASSERT(ret == 0, "compile start succeeds");
+
+    /* nft: dynamic set with timeout for banned IPs */
+    ASSERT(cmdlist_contains(&out, "add set ip filter ratelimit_wan2fw"),
+           "nft has ratelimit set for wan2fw");
+    ASSERT(cmdlist_contains(&out, "timeout 300s"),
+           "nft ratelimit set has correct ban timeout");
+
+    /* nft: drop rule for IPs already in the ban set */
+    ASSERT(cmdlist_contains(&out, "@ratelimit_wan2fw"),
+           "nft has rule referencing ratelimit set");
+    ASSERT(cmdlist_contains(&out, "RATELIMIT BAN wan2fw"),
+           "nft has ban log prefix");
+
+    /* nft: meter for per-source-IP rate tracking */
+    ASSERT(cmdlist_contains(&out, "meter ratelimit_meter_wan2fw"),
+           "nft uses meter for per-source-IP rate limiting");
+    ASSERT(cmdlist_contains(&out, "ip saddr limit rate over"),
+           "nft meter is keyed on ip saddr");
+
+    /* nft: add offending IPs to the ban set and drop */
+    ASSERT(cmdlist_contains(&out, "RATELIMIT ADD wan2fw"),
+           "nft has add-to-set log prefix");
+
+    /* Verify rate conversion: 5 connections per 60s -> 5/minute */
+    ASSERT(cmdlist_contains(&out, "5/minute"),
+           "nft rate is correctly computed as 5/minute");
+
+    fw_cmdlist_free(&out);
+}
+
+static void test_compile_rate_limit_ipt(void)
+{
+    printf("test_compile_rate_limit_ipt\n");
+    fw_config_t cfg;
+    char err[256];
+    int ret = fw_config_load("tests/fixtures/minimal.json", &cfg, err, sizeof(err));
+    ASSERT(ret == 0, "load config");
+    cfg.backend = BACKEND_IPT;
+
+    /* Enable rate limiting on wan2fw chain */
+    int idx = fw_config_chain_index("wan2fw");
+    ASSERT(idx >= 0, "wan2fw chain exists");
+    cfg.chains[idx].rate_limit.enabled = 1;
+    cfg.chains[idx].rate_limit.max_connections = 10;
+    cfg.chains[idx].rate_limit.period_seconds = 30;
+    cfg.chains[idx].rate_limit.ban_seconds = 600;
+
+    fw_cmdlist_t out;
+    ret = fw_compile_start(&cfg, &out);
+    ASSERT(ret == 0, "compile start succeeds");
+
+    /* ipt: recent module --rcheck for already-banned IPs */
+    ASSERT(cmdlist_contains(&out, "-m recent --name ratelimit_wan2fw --rcheck"),
+           "ipt has rcheck for banned IPs");
+    ASSERT(cmdlist_contains(&out, "--seconds 600"),
+           "ipt uses correct ban_seconds");
+
+    /* ipt: recent module --set must have a target (-j RETURN) */
+    ASSERT(cmdlist_contains(&out, "--set -j RETURN"),
+           "ipt --set rule has -j RETURN target");
+
+    /* ipt: recent module --update to detect rate exceeded */
+    ASSERT(cmdlist_contains(&out, "-m recent --name ratelimit_wan2fw --update"),
+           "ipt has --update rule for rate detection");
+    ASSERT(cmdlist_contains(&out, "--seconds 30"),
+           "ipt uses correct period_seconds");
+    ASSERT(cmdlist_contains(&out, "--hitcount 11"),
+           "ipt hitcount is max_connections + 1");
+
+    /* ipt: LOG and DROP for rate-limited IPs */
+    ASSERT(cmdlist_contains(&out, "RATELIMIT BAN wan2fw"),
+           "ipt has ban log prefix");
+    ASSERT(cmdlist_contains(&out, "RATELIMIT ADD wan2fw"),
+           "ipt has add log prefix");
+
+    fw_cmdlist_free(&out);
+}
+
+static void test_compile_rate_limit_period_mapping(void)
+{
+    printf("test_compile_rate_limit_period_mapping\n");
+    fw_config_t cfg;
+    char err[256];
+    int ret = fw_config_load("tests/fixtures/minimal.json", &cfg, err, sizeof(err));
+    ASSERT(ret == 0, "load config");
+    ASSERT(cfg.backend == BACKEND_NFT, "backend is nft");
+
+    int idx = fw_config_chain_index("lan2fw");
+    ASSERT(idx >= 0, "lan2fw chain exists");
+
+    fw_cmdlist_t out;
+
+    /* Test period_seconds=1 -> rate per second */
+    cfg.chains[idx].rate_limit.enabled = 1;
+    cfg.chains[idx].rate_limit.max_connections = 3;
+    cfg.chains[idx].rate_limit.period_seconds = 1;
+    cfg.chains[idx].rate_limit.ban_seconds = 60;
+
+    ret = fw_compile_start(&cfg, &out);
+    ASSERT(ret == 0, "compile start succeeds (1s period)");
+    ASSERT(cmdlist_contains(&out, "3/second"),
+           "period_seconds=1 maps to /second");
+    fw_cmdlist_free(&out);
+
+    /* Test period_seconds=10 -> scaled to /minute */
+    cfg.chains[idx].rate_limit.period_seconds = 10;
+    cfg.chains[idx].rate_limit.max_connections = 5;
+    ret = fw_compile_start(&cfg, &out);
+    ASSERT(ret == 0, "compile start succeeds (10s period)");
+    ASSERT(cmdlist_contains(&out, "30/minute"),
+           "period_seconds=10, max=5 maps to 30/minute (5*60/10)");
+    fw_cmdlist_free(&out);
+
+    /* Test period_seconds=3600 -> rate per hour */
+    cfg.chains[idx].rate_limit.period_seconds = 3600;
+    cfg.chains[idx].rate_limit.max_connections = 100;
+    ret = fw_compile_start(&cfg, &out);
+    ASSERT(ret == 0, "compile start succeeds (3600s period)");
+    ASSERT(cmdlist_contains(&out, "100/hour"),
+           "period_seconds=3600, max=100 maps to 100/hour");
+    fw_cmdlist_free(&out);
+
+    /* Test period_seconds=120 -> scaled to /hour */
+    cfg.chains[idx].rate_limit.period_seconds = 120;
+    cfg.chains[idx].rate_limit.max_connections = 10;
+    ret = fw_compile_start(&cfg, &out);
+    ASSERT(ret == 0, "compile start succeeds (120s period)");
+    ASSERT(cmdlist_contains(&out, "300/hour"),
+           "period_seconds=120, max=10 maps to 300/hour (10*3600/120)");
+    fw_cmdlist_free(&out);
+
+    /* Disable rate limit to leave config clean */
+    cfg.chains[idx].rate_limit.enabled = 0;
+}
+
+static void test_compile_rate_limit_disabled(void)
+{
+    printf("test_compile_rate_limit_disabled\n");
+    fw_config_t cfg;
+    char err[256];
+    int ret = fw_config_load("tests/fixtures/minimal.json", &cfg, err, sizeof(err));
+    ASSERT(ret == 0, "load config");
+
+    /* Ensure no rate limit rules appear when disabled (default) */
+    fw_cmdlist_t out;
+    ret = fw_compile_start(&cfg, &out);
+    ASSERT(ret == 0, "compile start succeeds");
+    ASSERT(!cmdlist_contains(&out, "RATELIMIT"),
+           "no ratelimit commands when disabled");
+    ASSERT(!cmdlist_contains(&out, "ratelimit_"),
+           "no ratelimit sets/meters when disabled");
+
+    fw_cmdlist_free(&out);
+}
+
 static void test_backend_get(void)
 {
     printf("test_backend_get\n");
@@ -279,6 +454,10 @@ int main(void)
     test_compile_stop();
     test_compile_reset();
     test_compile_full_config();
+    test_compile_rate_limit_nft();
+    test_compile_rate_limit_ipt();
+    test_compile_rate_limit_period_mapping();
+    test_compile_rate_limit_disabled();
 
     printf("\n%d/%d tests passed\n", tests_passed, tests_run);
     return tests_passed == tests_run ? 0 : 1;


### PR DESCRIPTION
## Task FW-0002 — Rate limiting and dynamic brute-force protection

### Summary
- Added `fw_rate_limit_t` to chain config with per-chain rate limiting
- Implemented nftables dynamic sets and iptables recent module backends
- Added CLI `set-ratelimit` command and REST API endpoints
- Updated config load/save/validate

### Related Issue
Refs #40 (FW-0002)

---
*Generated by Claude Code via `/task-pick`*